### PR TITLE
INTEXT-15: Rename the xq-datasource attribute to data-source

### DIFF
--- a/spring-integration-xquery/README.md
+++ b/spring-integration-xquery/README.md
@@ -89,11 +89,11 @@ The value or the expression to find the value for these named parameters is spec
 							input-channel="xpathRouterOne"
 							xquery="'Hello World'"
 							converter="converter"
-							xq-datasource="xqDs">
+							data-source="xqDs">
 		<int-xquery:xquery-parameter name="name" ref="name"/>
 	</int-xquery:xquery-router>
 
-The above config now specifies the *xquery* attribute to specify the query. It additionally has the *converter* and the *xq-datasource* attributes. The *converter* holds a reference to the bean which implements the `org.springframework.integration.xml.DefaultXmlPayloadConverter` interface. By default it uses `org.springframework.integration.xml.DefaultXmlPayloadConverter` Please note that this interface and the implementation is from  **spring-integration-xml** project. The *xq-datasource* attribute holds a reference to a bean that implements the `javax.xml.xquery.XQDataSource` interface. By default it will use `net.sf.saxon.xqj.SaxonXQDataSource` implementation.
+The above config now specifies the *xquery* attribute to specify the query. It additionally has the *converter* and the *data-source* attributes. The *converter* holds a reference to the bean which implements the `org.springframework.integration.xml.DefaultXmlPayloadConverter` interface. By default it uses `org.springframework.integration.xml.DefaultXmlPayloadConverter` Please note that this interface and the implementation is from  **spring-integration-xml** project. The *data-source* attribute holds a reference to a bean that implements the `javax.xml.xquery.XQDataSource` interface. By default it will use `net.sf.saxon.xqj.SaxonXQDataSource` implementation.
 
 #### With **xquery-file-resource** attribute
 
@@ -101,7 +101,7 @@ The above config now specifies the *xquery* attribute to specify the query. It a
 							input-channel="xpathRouterOne"
 							xquery-file-resource="org/springframework/integration/xquery/XQuery.xq"
 							converter="converter"
-							xq-datasource="xqDs">
+							data-source="xqDs">
 		<int-xquery:xquery-parameter name="name" expression="headers['name']"/>
 		<int-xquery:xquery-parameter name="class" value="1"/>
 	</int-xquery:xquery-router>
@@ -145,7 +145,7 @@ Similar to routers, transformers too support accepting the xquery as a child sub
 						output-channel="output"
 						xquery="'Hello World'"
 						converter="converter"
-						xq-datasource="xqDs"
+						data-source="xqDs"
 						format-output="true">
 	</int-xquery:xquery-transformer>
 
@@ -158,7 +158,7 @@ An additional attibute *format-output* is mentioned, the value could be *true* o
 						output-channel="output"
 						xquery-file-resource="classpath:org/springframework/integration/xquery/XQueryTransform.xq"
 						converter="converter"
-						xq-datasource="xqDs">
+						data-source="xqDs">
 	</int-xquery:xquery-transformer>
 
 ###Credits

--- a/spring-integration-xquery/src/main/java/org/springframework/integration/xquery/config/xml/IntegrationXQueryNamespaceHandler.java
+++ b/spring-integration-xquery/src/main/java/org/springframework/integration/xquery/config/xml/IntegrationXQueryNamespaceHandler.java
@@ -21,7 +21,8 @@ import org.springframework.integration.config.xml.AbstractIntegrationNamespaceHa
  * The namespace handler for the "int-xquery" namespace
  *
  * @author Amol Nayak
- * @since 2.2
+ *
+ * @since 1.0
  *
  */
 public class IntegrationXQueryNamespaceHandler extends

--- a/spring-integration-xquery/src/main/java/org/springframework/integration/xquery/config/xml/XQueryParserUtils.java
+++ b/spring-integration-xquery/src/main/java/org/springframework/integration/xquery/config/xml/XQueryParserUtils.java
@@ -40,15 +40,16 @@ import org.w3c.dom.NodeList;
  *
  * @author Amol Nayak
  *
- * @since 2.2
+ * @since 1.0
  *
  */
-public class XQueryParserUtils {
+public final class XQueryParserUtils {
 
 
 
 	private XQueryParserUtils() {
 		//prevent instantiation
+		throw new AssertionError("Cannot instantiate a utility class");
 	}
 
 	/**
@@ -59,7 +60,7 @@ public class XQueryParserUtils {
 	public static final AbstractBeanDefinition getXQueryExecutor(Element element) {
 		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(XQueryExecutor.class);
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "converter");
-		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "xq-datasource","xQDataSource");
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "data-source","xQDataSource");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "format-output");
 		setXQueryInBuilder(element, builder);
 		//lets get the parameter nodes

--- a/spring-integration-xquery/src/main/java/org/springframework/integration/xquery/config/xml/XQueryRouterParser.java
+++ b/spring-integration-xquery/src/main/java/org/springframework/integration/xquery/config/xml/XQueryRouterParser.java
@@ -28,7 +28,7 @@ import org.w3c.dom.Element;
  *
  * @author Amol Nayak
  *
- * @since 2.2
+ * @since 1.0
  *
  */
 public class XQueryRouterParser extends AbstractRouterParser {

--- a/spring-integration-xquery/src/main/java/org/springframework/integration/xquery/config/xml/XQueryTransformerParser.java
+++ b/spring-integration-xquery/src/main/java/org/springframework/integration/xquery/config/xml/XQueryTransformerParser.java
@@ -28,7 +28,8 @@ import org.w3c.dom.Node;
  * The parser for the XQuery transformer component
  *
  * @author Amol Nayak
- * @since 2.2
+ *
+ * @since 1.0
  *
  */
 public class XQueryTransformerParser extends AbstractTransformerParser {

--- a/spring-integration-xquery/src/main/java/org/springframework/integration/xquery/core/XQueryExecutor.java
+++ b/spring-integration-xquery/src/main/java/org/springframework/integration/xquery/core/XQueryExecutor.java
@@ -61,7 +61,7 @@ import org.w3c.dom.Node;
  *
  * @author Amol Nayak
  *
- * @since 2.2
+ * @since 1.0
  *
  */
 public class XQueryExecutor implements InitializingBean,BeanClassLoaderAware {

--- a/spring-integration-xquery/src/main/java/org/springframework/integration/xquery/router/XQueryRouter.java
+++ b/spring-integration-xquery/src/main/java/org/springframework/integration/xquery/router/XQueryRouter.java
@@ -28,7 +28,8 @@ import org.springframework.util.Assert;
  * to which the message will be routed
  *
  * @author Amol Nayak
- * @since 2.2
+ *
+ * @since 1.0
  *
  */
 public class XQueryRouter extends AbstractMappingMessageRouter {

--- a/spring-integration-xquery/src/main/java/org/springframework/integration/xquery/support/AbstractXQueryResultMapper.java
+++ b/spring-integration-xquery/src/main/java/org/springframework/integration/xquery/support/AbstractXQueryResultMapper.java
@@ -48,10 +48,8 @@ import java.math.BigInteger;
 
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.TransformerFactoryConfigurationError;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.xquery.XQException;
@@ -65,7 +63,8 @@ import org.w3c.dom.Node;
 /**
  * The absract base class for {@link XQueryResultMapper} implementations
  * @author Amol Nayak
- * @since 2.2
+ *
+ * @since 1.0
  *
  */
 public abstract class AbstractXQueryResultMapper<T> implements XQueryResultMapper<T> {
@@ -258,8 +257,6 @@ public abstract class AbstractXQueryResultMapper<T> implements XQueryResultMappe
 	/**Transforms the given {@link Node} to a String
 	 * @param n
 	 * @return
-	 * @throws TransformerConfigurationException
-	 * @throws TransformerFactoryConfigurationError
 	 * @throws TransformerException
 	 */
 	protected String transformNodeToString(Node n)

--- a/spring-integration-xquery/src/main/java/org/springframework/integration/xquery/support/BooleanResultMapper.java
+++ b/spring-integration-xquery/src/main/java/org/springframework/integration/xquery/support/BooleanResultMapper.java
@@ -29,7 +29,7 @@ import org.w3c.dom.Node;
  *
  * @author Amol Nayak
  *
- * @since 2.2
+ * @since 1.0
  *
  */
 public class BooleanResultMapper extends AbstractXQueryResultMapper<Boolean> {

--- a/spring-integration-xquery/src/main/java/org/springframework/integration/xquery/support/NodeResultMapper.java
+++ b/spring-integration-xquery/src/main/java/org/springframework/integration/xquery/support/NodeResultMapper.java
@@ -29,7 +29,7 @@ import org.w3c.dom.Node;
  *
  * @author Amol Nayak
  *
- * @since 2.2
+ * @since 1.0
  *
  */
 public class NodeResultMapper extends AbstractXQueryResultMapper<Node> {

--- a/spring-integration-xquery/src/main/java/org/springframework/integration/xquery/support/NumberResultMapper.java
+++ b/spring-integration-xquery/src/main/java/org/springframework/integration/xquery/support/NumberResultMapper.java
@@ -30,7 +30,7 @@ import org.w3c.dom.Node;
  *
  * @author Amol Nayak
  *
- * @since 2.2
+ * @since 1.0
  *
  */
 public class NumberResultMapper extends AbstractXQueryResultMapper<Number> {

--- a/spring-integration-xquery/src/main/java/org/springframework/integration/xquery/support/StringResultMapper.java
+++ b/spring-integration-xquery/src/main/java/org/springframework/integration/xquery/support/StringResultMapper.java
@@ -29,7 +29,7 @@ import org.w3c.dom.Node;
  *
  * @author Amol Nayak
  *
- * @since 2.2
+ * @since 1.0
  *
  */
 public class StringResultMapper extends AbstractXQueryResultMapper<String> {

--- a/spring-integration-xquery/src/main/java/org/springframework/integration/xquery/support/XQueryParameter.java
+++ b/spring-integration-xquery/src/main/java/org/springframework/integration/xquery/support/XQueryParameter.java
@@ -28,7 +28,8 @@ import org.springframework.util.StringUtils;
  * instance
  *
  * @author Amol Nayak
- * @since 2.2
+ *
+ * @since 1.0
  *
  */
 public class XQueryParameter {

--- a/spring-integration-xquery/src/main/java/org/springframework/integration/xquery/support/XQueryResultMapper.java
+++ b/spring-integration-xquery/src/main/java/org/springframework/integration/xquery/support/XQueryResultMapper.java
@@ -24,7 +24,8 @@ import javax.xml.xquery.XQResultSequence;
  * returned by XQuery execution to a List of the specified type
  *
  * @author Amol Nayak
- * @since 2.2
+ *
+ * @since 1.0
  *
  */
 public interface XQueryResultMapper<T> {

--- a/spring-integration-xquery/src/main/java/org/springframework/integration/xquery/support/XQueryUtils.java
+++ b/spring-integration-xquery/src/main/java/org/springframework/integration/xquery/support/XQueryUtils.java
@@ -34,10 +34,10 @@ import org.springframework.util.Assert;
  *
  * @author Amol Nayak
  *
- * @since 2.2
+ * @since 1.0
  *
  */
-public class XQueryUtils {
+public final class XQueryUtils {
 
 	private static final Log logger = LogFactory.getLog(XQueryUtils.class);
 

--- a/spring-integration-xquery/src/main/java/org/springframework/integration/xquery/transformer/XQueryTransformer.java
+++ b/spring-integration-xquery/src/main/java/org/springframework/integration/xquery/transformer/XQueryTransformer.java
@@ -41,7 +41,7 @@ import org.w3c.dom.Node;
  *
  * @author Amol Nayak
  *
- * @since 2.2
+ * @since 1.0
  *
  */
 @SuppressWarnings("rawtypes")

--- a/spring-integration-xquery/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-xquery/src/main/resources/META-INF/spring.schemas
@@ -1,2 +1,2 @@
-http\://www.springframework.org/schema/integration/xquery/spring-integration-xquery-2.2.xsd=org/springframework/integration/xquery/config/spring-integration-xquery-2.2.xsd
-http\://www.springframework.org/schema/integration/xquery/spring-integration-xquery.xsd=org/springframework/integration/xquery/config/spring-integration-xquery-2.2.xsd
+http\://www.springframework.org/schema/integration/xquery/spring-integration-xquery-1.0.xsd=org/springframework/integration/xquery/config/spring-integration-xquery-1.0.xsd
+http\://www.springframework.org/schema/integration/xquery/spring-integration-xquery.xsd=org/springframework/integration/xquery/config/spring-integration-xquery-1.0.xsd

--- a/spring-integration-xquery/src/main/resources/org/springframework/integration/xquery/config/spring-integration-xquery-1.0.xsd
+++ b/spring-integration-xquery/src/main/resources/org/springframework/integration/xquery/config/spring-integration-xquery-1.0.xsd
@@ -53,7 +53,7 @@
 				the xquery components
 			</xsd:documentation>
 		</xsd:annotation>
-		<xsd:attribute name="xq-datasource" type="xsd:string"
+		<xsd:attribute name="data-source" type="xsd:string"
 			use="optional">
 			<xsd:annotation>
 				<xsd:documentation>
@@ -63,6 +63,11 @@
 					provided, then the default
 					implementation will be used.
 				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="javax.xml.xquery.XQDataSource" />
+					</tool:annotation>
+				</xsd:appinfo>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="xquery-file-resource" type="xsd:string"

--- a/spring-integration-xquery/src/test/java/org/springframework/integration/xquery/DummyXmlPayloadConverter.java
+++ b/spring-integration-xquery/src/test/java/org/springframework/integration/xquery/DummyXmlPayloadConverter.java
@@ -25,7 +25,8 @@ import org.w3c.dom.Node;
  * The Dummy Xml payload converter class that would be used for parser tests
  *
  * @author Amol Nayak
- * @since 2.2
+ *
+ * @since 1.0
  *
  */
 public class DummyXmlPayloadConverter implements XmlPayloadConverter {

--- a/spring-integration-xquery/src/test/java/org/springframework/integration/xquery/config/xml/XQueryRouterParserTests.java
+++ b/spring-integration-xquery/src/test/java/org/springframework/integration/xquery/config/xml/XQueryRouterParserTests.java
@@ -38,7 +38,7 @@ import org.springframework.integration.xquery.support.XQueryParameter;
  *
  * @author Amol Nayak
  *
- * @since 2.2
+ * @since 1.0
  *
  */
 public class XQueryRouterParserTests {

--- a/spring-integration-xquery/src/test/java/org/springframework/integration/xquery/config/xml/XQueryTransformerParserTests.java
+++ b/spring-integration-xquery/src/test/java/org/springframework/integration/xquery/config/xml/XQueryTransformerParserTests.java
@@ -45,7 +45,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  *
  * @author Amol Nayak
  *
- * @since 2.2
+ * @since 1.0
  *
  */
 @ContextConfiguration

--- a/spring-integration-xquery/src/test/java/org/springframework/integration/xquery/core/AbstractXQueryExecutorTests.java
+++ b/spring-integration-xquery/src/test/java/org/springframework/integration/xquery/core/AbstractXQueryExecutorTests.java
@@ -46,7 +46,8 @@ import org.w3c.dom.Node;
  * The base test class for the XQueryExecutor tests
  *
  * @author Amol Nayak
- * @since 2.2
+ *
+ * @since 1.0
  *
  */
 public abstract class AbstractXQueryExecutorTests {

--- a/spring-integration-xquery/src/test/java/org/springframework/integration/xquery/core/SaxonXQueryExecutorTests.java
+++ b/spring-integration-xquery/src/test/java/org/springframework/integration/xquery/core/SaxonXQueryExecutorTests.java
@@ -22,7 +22,7 @@ package org.springframework.integration.xquery.core;
  *
  * @author Amol Nayak
  *
- * @since 2.2
+ * @since 1.0
  *
  */
 public class SaxonXQueryExecutorTests extends AbstractXQueryExecutorTests {

--- a/spring-integration-xquery/src/test/java/org/springframework/integration/xquery/core/SednaXQueryExecutorTests.java
+++ b/spring-integration-xquery/src/test/java/org/springframework/integration/xquery/core/SednaXQueryExecutorTests.java
@@ -42,7 +42,7 @@ import net.xqj.sedna.SednaXQDataSource;
  *
  * @author Amol Nayak
  *
- * @since 2.2
+ * @since 1.0
  *
  */
 public class SednaXQueryExecutorTests extends AbstractXQueryExecutorTests {

--- a/spring-integration-xquery/src/test/java/org/springframework/integration/xquery/router/XQueryRouterTests.java
+++ b/spring-integration-xquery/src/test/java/org/springframework/integration/xquery/router/XQueryRouterTests.java
@@ -29,7 +29,8 @@ import org.springframework.integration.xquery.core.XQueryExecutor;
  * The Test class for the XQuery router
  *
  * @author Amol Nayak
- * @since 2.2
+ *
+ * @since 1.0
  *
  */
 public class XQueryRouterTests {

--- a/spring-integration-xquery/src/test/java/org/springframework/integration/xquery/support/XQueryParameterTests.java
+++ b/spring-integration-xquery/src/test/java/org/springframework/integration/xquery/support/XQueryParameterTests.java
@@ -31,7 +31,7 @@ import org.springframework.integration.test.util.TestUtils;
  *
  * @author Amol Nayak
  *
- * @since 2.2
+ * @since 1.0
  *
  */
 public class XQueryParameterTests {

--- a/spring-integration-xquery/src/test/java/org/springframework/integration/xquery/transformer/XQueryTransformerTests.java
+++ b/spring-integration-xquery/src/test/java/org/springframework/integration/xquery/transformer/XQueryTransformerTests.java
@@ -34,7 +34,8 @@ import org.w3c.dom.Node;
  * The Test class for the {@link XQueryTransformer} class
  *
  * @author Amol Nayak
- * @since 2.2
+ *
+ * @since 1.0
  *
  */
 public class XQueryTransformerTests {

--- a/spring-integration-xquery/src/test/resources/org/springframework/integration/xquery/config/xml/XQueryRouterParserTests-context.xml
+++ b/spring-integration-xquery/src/test/resources/org/springframework/integration/xquery/config/xml/XQueryRouterParserTests-context.xml
@@ -28,7 +28,7 @@
 							input-channel="xpathRouterOne"
 							xquery="'Hello World'"
 							converter="converter"
-							xq-datasource="xqDs">
+							data-source="xqDs">
 		<int-xquery:xquery-parameter name="name" ref="name"/>
 	</int-xquery:xquery-router>
 
@@ -36,7 +36,7 @@
 							input-channel="xpathRouterOne"
 							xquery-file-resource="classpath:org/springframework/integration/xquery/XQuery.xq"
 							converter="converter"
-							xq-datasource="xqDs">
+							data-source="xqDs">
 		<int-xquery:xquery-parameter name="name" expression="headers['name']"/>
 		<int-xquery:xquery-parameter name="class" value="1"/>
 	</int-xquery:xquery-router>
@@ -47,7 +47,7 @@
 							input-channel="xpathRouterOne"
 							xquery-file-resource="org/springframework/integration/xquery/XQuery.xq"
 							converter="converter"
-							xq-datasource="xqDs">
+							data-source="xqDs">
 		<int-xquery:xquery-parameter name="name" expression="headers['name']"/>
 		<int-xquery:xquery-parameter name="class" value="1"/>
 	</int-xquery:xquery-router>

--- a/spring-integration-xquery/src/test/resources/org/springframework/integration/xquery/config/xml/XQueryTransformerParserTests-context.xml
+++ b/spring-integration-xquery/src/test/resources/org/springframework/integration/xquery/config/xml/XQueryTransformerParserTests-context.xml
@@ -33,7 +33,7 @@
 						output-channel="output"
 						xquery="'Hello World'"
 						converter="converter"
-						xq-datasource="xqDs"
+						data-source="xqDs"
 						format-output="true">
 	</int-xquery:xquery-transformer>
 
@@ -42,7 +42,7 @@
 						output-channel="output"
 						xquery-file-resource="classpath:org/springframework/integration/xquery/XQueryTransform.xq"
 						converter="converter"
-						xq-datasource="xqDs">
+						data-source="xqDs">
 	</int-xquery:xquery-transformer>
 
 	<int-xquery:xquery-transformer id="booleanResultTypeTransformer"
@@ -50,21 +50,21 @@
 								output-channel="output"
 								result-type="java.lang.Boolean"
 								xquery-file-resource="classpath:org/springframework/integration/xquery/XQueryTransform.xq"
-								xq-datasource="xqDs"/>
+								data-source="xqDs"/>
 
 	<int-xquery:xquery-transformer id="stringResultTypeTransformer"
 								input-channel="stringResultTypeTransformerIP"
 								output-channel="output"
 								result-type="string"
 								xquery-file-resource="classpath:org/springframework/integration/xquery/XQueryTransform.xq"
-								xq-datasource="xqDs"/>
+								data-source="xqDs"/>
 
 	<int-xquery:xquery-transformer id="customXQueryResultMapper"
 								input-channel="stringResultTypeTransformerIP"
 								output-channel="output"
 								xquery-result-mapper="xqueryResultMapper"
 								xquery-file-resource="classpath:org/springframework/integration/xquery/XQueryTransform.xq"
-								xq-datasource="xqDs"/>
+								data-source="xqDs"/>
 
 	<bean id="converter" class="org.springframework.integration.xquery.DummyXmlPayloadConverter"/>
 


### PR DESCRIPTION
The XQ Datasource attribute is named data-source from xq-datasource to be consistent with other components available in Spring Integration. 
The version in the file and the xsd was 2.2 and was not changed to 1.0 to be in sync with the build version in the pom.xml. Changes to files are now made to reflect the correct version

The JIRA for the change is https://jira.springsource.org/browse/INTEXT-15
