### PR TITLE
INTEXT-80 - FIX S3 ConnectionPoolTimeoutException

### DIFF
--- a/spring-integration-aws/src/main/java/org/springframework/integration/aws/s3/InboundFileSynchronizationImpl.java
+++ b/spring-integration-aws/src/main/java/org/springframework/integration/aws/s3/InboundFileSynchronizationImpl.java
@@ -45,6 +45,7 @@ import org.springframework.util.StringUtils;
  * be checked against the
  *
  * @author Amol Nayak
+ * @author Christos Kapasakalidis
  *
  * @since 0.5
  *
@@ -145,7 +146,7 @@ public class InboundFileSynchronizationImpl implements InboundFileSynchronizer,I
 							s3Object = client.getObject(bucketName, "/", key);
 							synchronizeObjectWithFile(localDirectory,summary,s3Object);
 						} finally {
-							if(s3Object.getInputStream() != null) {
+							if(s3Object != null && s3Object.getInputStream() != null) {
 								s3Object.getInputStream().close();
 							}
 						}


### PR DESCRIPTION
When synchronizing to local directory, getObject was called without
ever closing the InputStream that the SDK opens, causing an
"org.apache.http.conn.ConnectionPoolTimeoutException: Timeout waiting
for connection" exception. To fix that, after synchronization, the
inputStream of the s3Object is closed, causing the s3 client to release
the connection.

Issue: INTEXT-80

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.
