### PR TITLE
XD-1170 Updated splunk adapter to use SI 4.0

### DIFF
--- a/spring-integration-splunk/build.gradle
+++ b/spring-integration-splunk/build.gradle
@@ -17,7 +17,7 @@ apply plugin: 'idea'
 group = 'org.springframework.integration'
 
 repositories {
-	maven { url 'http://repo.springsource.org/libs-milestone' }
+	maven { url 'http://repo.springsource.org/milestone' }
 	maven { url 'http://repo.springsource.org/plugins-release' } // for bundlor
 }
 
@@ -43,6 +43,7 @@ configurations {
 
 dependencies {
 	compile("com.splunk:splunk:$splunkVersion")
+	compile "org.springframework:spring-core:$springVersion"
 	compile "org.springframework:spring-beans:$springVersion"
 	compile "org.springframework:spring-context:$springVersion"
 	compile "org.springframework:spring-expression:$springVersion"

--- a/spring-integration-splunk/gradle.properties
+++ b/spring-integration-splunk/gradle.properties
@@ -1,10 +1,10 @@
 junitVersion=4.8.2
 jodaTimeVersion=2.1
-springVersion=3.1.3.RELEASE
-splunkVersion=1.0.0
+springVersion=4.0.2.RELEASE
+splunkVersion=1.2.0
 log4jVersion=1.2.12
 version=1.0.0.BUILD-SNAPSHOT
-springIntegrationVersion=2.2.1.RELEASE
+springIntegrationVersion=4.0.0.M3
 cglibVersion=2.2
 commonsPoolVersion=1.6
 mockitoVersion=1.9.0

--- a/spring-integration-splunk/src/main/java/org/springframework/integration/splunk/inbound/SplunkPollingChannelAdapter.java
+++ b/spring-integration-splunk/src/main/java/org/springframework/integration/splunk/inbound/SplunkPollingChannelAdapter.java
@@ -17,7 +17,7 @@ package org.springframework.integration.splunk.inbound;
 
 import java.util.List;
 
-import org.springframework.integration.Message;
+import org.springframework.messaging.Message;
 import org.springframework.integration.context.IntegrationObjectSupport;
 import org.springframework.integration.core.MessageSource;
 import org.springframework.integration.splunk.event.SplunkEvent;

--- a/spring-integration-splunk/src/main/java/org/springframework/integration/splunk/outbound/SplunkOutboundChannelAdapter.java
+++ b/spring-integration-splunk/src/main/java/org/springframework/integration/splunk/outbound/SplunkOutboundChannelAdapter.java
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.splunk.outbound;
 
-import org.springframework.integration.Message;
+import org.springframework.messaging.Message;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.integration.splunk.support.SplunkExecutor;
 import org.springframework.integration.support.MessageBuilder;
@@ -47,13 +47,6 @@ public class SplunkOutboundChannelAdapter extends AbstractReplyProducingMessageH
 		this.splunkExecutor = splunkExecutor;
 	}
 
-	/**
-	 *
-	 */
-	@Override
-	protected void onInit() {
-		super.onInit();
-	}
 
 	@Override
 	protected Object handleRequestMessage(Message<?> requestMessage) {

--- a/spring-integration-splunk/src/main/java/org/springframework/integration/splunk/support/SplunkExecutor.java
+++ b/spring-integration-splunk/src/main/java/org/springframework/integration/splunk/support/SplunkExecutor.java
@@ -19,9 +19,9 @@ import java.util.List;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.springframework.integration.Message;
-import org.springframework.integration.MessageHandlingException;
-import org.springframework.integration.MessagingException;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHandlingException;
+import org.springframework.messaging.MessagingException;
 import org.springframework.integration.splunk.core.DataReader;
 import org.springframework.integration.splunk.core.DataWriter;
 import org.springframework.integration.splunk.event.SplunkEvent;

--- a/spring-integration-splunk/src/test/java/org/springframework/integration/splunk/outbound/SplunkOutboundChannelAdapterTests.java
+++ b/spring-integration-splunk/src/test/java/org/springframework/integration/splunk/outbound/SplunkOutboundChannelAdapterTests.java
@@ -21,7 +21,7 @@ import junit.framework.Assert;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.integration.Message;
+import org.springframework.messaging.Message;
 import org.springframework.integration.splunk.support.SplunkExecutor;
 
 /**

--- a/spring-integration-splunk/src/test/java/org/springframework/integration/splunk/support/SplunkExecutorTests.java
+++ b/spring-integration-splunk/src/test/java/org/springframework/integration/splunk/support/SplunkExecutorTests.java
@@ -26,7 +26,7 @@ import junit.framework.Assert;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.integration.Message;
+import org.springframework.messaging.Message;
 import org.springframework.integration.splunk.core.DataReader;
 import org.springframework.integration.splunk.core.DataWriter;
 import org.springframework.integration.splunk.event.SplunkEvent;


### PR DESCRIPTION
- Updated dependencies
  -- SI Repository reference snapshot, this will have to be updated when SI 4.0 is available.
- Updated package for Message

Used Milestone repo instead of snapshot.

Dependency uses M3.
