### PR TITLE
Update to spring/spring-integration 4.x release.

### DIFF
--- a/spring-integration-kafka/build.gradle
+++ b/spring-integration-kafka/build.gradle
@@ -29,8 +29,8 @@ ext {
 	log4jVersion = '1.2.12'
 	mockitoVersion = '1.9.5'
 	scalaVersion = '2.9.2'
-	springVersion = '3.1.3.RELEASE'
-	springIntegrationVersion = '2.2.4.RELEASE'
+	springVersion = '4.0.5.RELEASE'
+	springIntegrationVersion = '4.0.2.RELEASE'
 
 	idPrefix = 'kafka'
 
@@ -64,9 +64,10 @@ configurations {
 }
 
 dependencies {
-	compile "org.springframework:spring-beans:$springVersion"
+	compile "org.springframework:spring-beans:$springVersion" 
 	compile "org.springframework:spring-context:$springVersion"
 	compile "org.springframework:spring-expression:$springVersion"
+	compile "org.springframework:spring-messaging:$springVersion"
 	compile "org.springframework.integration:spring-integration-core:$springIntegrationVersion"
 	compile "org.apache.avro:avro:1.7.3"
 	compile "org.apache.avro:avro-compiler:1.7.3"

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaHighLevelConsumerMessageSource.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaHighLevelConsumerMessageSource.java
@@ -15,10 +15,10 @@
  */
 package org.springframework.integration.kafka.inbound;
 
-import org.springframework.integration.Message;
 import org.springframework.integration.context.IntegrationObjectSupport;
 import org.springframework.integration.core.MessageSource;
 import org.springframework.integration.kafka.support.KafkaConsumerContext;
+import org.springframework.messaging.Message;
 
 import java.util.List;
 import java.util.Map;

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandler.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandler.java
@@ -15,9 +15,9 @@
  */
 package org.springframework.integration.kafka.outbound;
 
-import org.springframework.integration.Message;
 import org.springframework.integration.handler.AbstractMessageHandler;
 import org.springframework.integration.kafka.support.KafkaProducerContext;
+import org.springframework.messaging.Message;
 
 /**
  * @author Soby Chacko

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/support/ConsumerConfiguration.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/support/ConsumerConfiguration.java
@@ -18,7 +18,7 @@ import kafka.message.MessageAndMetadata;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.springframework.integration.MessagingException;
+import org.springframework.messaging.MessagingException;
 
 /**
  * @author Soby Chacko

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/support/KafkaConsumerContext.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/support/KafkaConsumerContext.java
@@ -19,9 +19,9 @@ import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.ListableBeanFactory;
-import org.springframework.integration.Message;
 import org.springframework.integration.kafka.core.KafkaConsumerDefaults;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.Message;
 
 import java.util.Collection;
 import java.util.HashMap;

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/support/KafkaProducerContext.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/support/KafkaProducerContext.java
@@ -19,11 +19,12 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Properties;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.*;
-import org.springframework.integration.Message;
+import org.springframework.messaging.Message;
 
 /**
  * @author Soby Chacko
@@ -52,7 +53,7 @@ public class KafkaProducerContext<K,V> implements BeanFactoryAware {
 				return producerConfiguration;
 			}
 		}
-		LOGGER.error("No is producer-configuration defined for topic " + topic + ". cannot send message");
+		LOGGER.error("No producer-configuration defined for topic " + topic + ". cannot send message");
 		return null;
 	}
 

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/support/ProducerConfiguration.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/support/ProducerConfiguration.java
@@ -16,7 +16,7 @@ import kafka.serializer.DefaultEncoder;
 
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.springframework.integration.Message;
+import org.springframework.messaging.Message;
 
 /**
  * @author Soby Chacko

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/support/KafkaConsumerContextTest.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/support/KafkaConsumerContextTest.java
@@ -19,7 +19,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.ListableBeanFactory;
-import org.springframework.integration.Message;
+import org.springframework.messaging.Message;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/support/ProducerConfigurationTests.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/support/ProducerConfigurationTests.java
@@ -23,13 +23,13 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-import org.springframework.integration.Message;
 import org.springframework.integration.kafka.serializer.avro.AvroReflectDatumBackedKafkaEncoder;
 import org.springframework.integration.kafka.test.utils.NonSerializableTestKey;
 import org.springframework.integration.kafka.test.utils.NonSerializableTestPayload;
 import org.springframework.integration.kafka.test.utils.TestKey;
 import org.springframework.integration.kafka.test.utils.TestPayload;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.Message;
 
 import java.io.ByteArrayInputStream;
 import java.io.NotSerializableException;


### PR DESCRIPTION
Update the sprig-integration-kafka module to use Spring 4.0.5.RELEASE and Spring Integration 4.0.2.RELEASE. All unit tests were verified to still pass and code has been tested in a sample application that makes use of a Spring Integration flow that reads from and writes to Kafka.
