### PR TITLE
count = 0 parameter must be send to splunk to get unlimited number of responses

### DIFF
--- a/spring-integration-splunk/src/main/java/org/springframework/integration/splunk/support/SplunkDataReader.java
+++ b/spring-integration-splunk/src/main/java/org/springframework/integration/splunk/support/SplunkDataReader.java
@@ -413,6 +413,7 @@ public class SplunkDataReader implements DataReader, InitializingBean {
 		if (count == 0 || total < count) {
 			InputStream stream = null;
 			Args outputArgs = new Args();
+			outputArgs.put("count", count);
 			outputArgs.put("output_mode", "xml");
 			stream = job.getResults(outputArgs);
 


### PR DESCRIPTION
In some case, we don't have a limited number of responses which is possible with the argument count set to 0.
Here a simple fix for that.
