### PR TITLE
Add the Spring IO plugin to Splunk extension

### DIFF
--- a/spring-integration-splunk/build.gradle
+++ b/spring-integration-splunk/build.gradle
@@ -6,6 +6,7 @@ buildscript {
 	}
 	dependencies {
 		classpath 'org.springframework.build.gradle:docbook-reference-plugin:0.2.8'
+		classpath 'org.springframework.build.gradle:spring-io-plugin:0.0.3.RELEASE'
 	}
 }
 
@@ -13,6 +14,18 @@ apply plugin: 'java'
 apply from:   "${rootProject.projectDir}/publish-maven.gradle"
 apply plugin: 'eclipse'
 apply plugin: 'idea'
+
+if (project.hasProperty('platformVersion')) {
+	apply plugin: 'spring-io'
+
+	repositories {
+		maven { url "https://repo.spring.io/libs-snapshot" }
+	}
+
+	dependencies {
+		springIoVersions "io.spring.platform:platform-versions:${platformVersion}@properties"
+	}
+}
 
 group = 'org.springframework.integration'
 


### PR DESCRIPTION
The Splunk extension is planned for inclusion in Spring IO Platform 1.1 as it's a dependency of Spring XD. This PR adds the Spring IO plugin to the Splunk extension to make it easier to verify its Platform compliance. Please see the commit comment for some more details of the changes.
