### PR TITLE
Update Kafka adapter to 1.0.0.M2.SNAPSHOT

### DIFF
--- a/samples/kafka/build.gradle
+++ b/samples/kafka/build.gradle
@@ -41,11 +41,11 @@ dependencies {
 		"org.apache.avro:avro:1.7.3",
 		"org.apache.avro:avro-compiler:1.7.3"
 	])
-	compile "org.springframework:spring-beans:3.1.3.RELEASE"
-	compile "org.springframework:spring-context:3.1.3.RELEASE"
-	compile "org.springframework:spring-expression:3.1.3.RELEASE"
-	compile "org.springframework.integration:spring-integration-stream:2.2.0.RELEASE"
-	compile("org.springframework.integration:spring-integration-kafka:0.5.0.BUILD-SNAPSHOT") {
+	compile "org.springframework:spring-beans:4.0.6.RELEASE"
+	compile "org.springframework:spring-context:4.0.6.RELEASE"
+	compile "org.springframework:spring-expression:4.0.6.RELEASE"
+	compile "org.springframework.integration:spring-integration-stream:4.0.3.RELEASE"
+	compile("org.springframework.integration:spring-integration-kafka:1.0.0.M2.BUILD-SNAPSHOT") {
 		exclude module: 'log4j'
 		exclude module: 'jms'
 		exclude module: 'jmxtools'

--- a/samples/kafka/src/main/java/org/springframework/integration/samples/kafka/outbound/CustomPartitioner.java
+++ b/samples/kafka/src/main/java/org/springframework/integration/samples/kafka/outbound/CustomPartitioner.java
@@ -22,14 +22,14 @@ import kafka.producer.Partitioner;
  *
  * This class is for internal use only and therefore is at default access level
  */
-class CustomPartitioner<T> implements Partitioner<T> {
+class CustomPartitioner implements Partitioner {
 	/**
 	 * Uses the key to calculate a partition bucket id for routing
 	 * the data to the appropriate broker partition
 	 * @return an integer between 0 and numPartitions-1
 	 */
 	@Override
-	public int partition(final T key, final int numPartitions) {
+	public int partition(final Object key, final int numPartitions) {
 		final String s = (String) key;
 		final Integer i = Integer.parseInt(s);
 		return i % numPartitions;

--- a/samples/kafka/src/main/java/org/springframework/integration/samples/kafka/outbound/OutboundRunner.java
+++ b/samples/kafka/src/main/java/org/springframework/integration/samples/kafka/outbound/OutboundRunner.java
@@ -18,9 +18,9 @@ package org.springframework.integration.samples.kafka.outbound;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
-import org.springframework.integration.MessageChannel;
 import org.springframework.integration.samples.kafka.user.User;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.MessageChannel;
 
 public class OutboundRunner {
 	private static final String CONFIG = "kafkaOutboundAdapterParserTests-context.xml";

--- a/samples/kafka/src/main/java/org/springframework/integration/samples/kafka/outbound/PartitionlessTransformer.java
+++ b/samples/kafka/src/main/java/org/springframework/integration/samples/kafka/outbound/PartitionlessTransformer.java
@@ -15,9 +15,9 @@
  */
 package org.springframework.integration.samples.kafka.outbound;
 
-import org.springframework.integration.Message;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.transformer.Transformer;
+import org.springframework.messaging.Message;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -36,13 +36,13 @@ public class PartitionlessTransformer implements Transformer {
 		final Map<String, Map<Integer, List<Object>>> origData =
 				(Map<String, Map<Integer, List<Object>>>) message.getPayload();
 
-		final Map<String, List<Object>> nonPartitionedData = new HashMap<String, List<Object>>();
+		final Map<String, List<Object>> nonPartitionedData = new HashMap<>();
 
 		for(final String topic : origData.keySet()) {
 			final Map<Integer, List<Object>> partitionedData = origData.get(topic);
 			final Collection<List<Object>> nonPartitionedDataFromTopic = partitionedData.values();
 
-			final List<Object> mergedList = new ArrayList<Object>();
+			final List<Object> mergedList = new ArrayList<>();
 
 			for (final List<Object> l : nonPartitionedDataFromTopic){
 				mergedList.addAll(l);

--- a/spring-integration-kafka/build.gradle
+++ b/spring-integration-kafka/build.gradle
@@ -19,7 +19,7 @@ sourceCompatibility = targetCompatibility = 1.6
 ext {
 	avroVersion = '1.7.6'
 	jacocoVersion = '0.7.0.201403182114'
-	kafkaVersion = '0.8.0'
+	kafkaVersion = '0.8.1.1'
 	metricsVersion = '2.2.0'
 	scalaVersion = '2.10'
 	springIntegrationVersion = '4.0.3.RELEASE'

--- a/spring-integration-kafka/gradle.properties
+++ b/spring-integration-kafka/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.0.BUILD-SNAPSHOT
+version=1.0.0.M2.BUILD-SNAPSHOT

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/support/DefaultPartitioner.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/support/DefaultPartitioner.java
@@ -24,14 +24,15 @@ import kafka.utils.Utils;
  *
  * This class is for internal use only and therefore is at default access level
  */
-class DefaultPartitioner<T> implements Partitioner<T> {
+class DefaultPartitioner implements Partitioner {
 	/**
 	 * Uses the key to calculate a partition bucket id for routing
 	 * the data to the appropriate broker partition
 	 * @return an integer between 0 and numPartitions-1
 	 */
 	@Override
-	public int partition(final T key, final int numPartitions) {
+	public int partition(final Object key, final int numPartitions) {
 		return Utils.abs(key.hashCode()) % numPartitions;
 	}
+
 }

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/support/ProducerFactoryBean.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/support/ProducerFactoryBean.java
@@ -71,7 +71,7 @@ public class ProducerFactoryBean<K,V> implements FactoryBean<Producer<K,V>> {
         LOGGER.info("Using producer properties => " + props);
 		final ProducerConfig config = new ProducerConfig(props);
 		final EventHandler<K, V> eventHandler = new DefaultEventHandler<K, V>(config,
-				producerMetadata.getPartitioner() == null ? new DefaultPartitioner<K>() : producerMetadata.getPartitioner(),
+				producerMetadata.getPartitioner() == null ? new DefaultPartitioner() : producerMetadata.getPartitioner(),
 				producerMetadata.getValueEncoder(), producerMetadata.getKeyEncoder(),
 				new ProducerPool(config), new HashMap<String, kafka.api.TopicMetadata>());
 

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/support/ProducerMetadata.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/support/ProducerMetadata.java
@@ -35,7 +35,7 @@ public class ProducerMetadata<K,V> implements InitializingBean {
 	private Class<V> valueClassType;
 	private final String topic;
 	private String compressionCodec = "default";
-	private Partitioner<K> partitioner;
+	private Partitioner partitioner;
 	private boolean async = false;
 	private String batchNumMessages;
 
@@ -94,11 +94,11 @@ public class ProducerMetadata<K,V> implements InitializingBean {
 		this.compressionCodec = compressionCodec;
 	}
 
-	public Partitioner<K> getPartitioner() {
+	public Partitioner getPartitioner() {
 		return partitioner;
 	}
 
-	public void setPartitioner(final Partitioner<K> partitioner) {
+	public void setPartitioner(final Partitioner partitioner) {
 		this.partitioner = partitioner;
 	}
 

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/support/ConsumerConfigurationTests.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/support/ConsumerConfigurationTests.java
@@ -262,9 +262,25 @@ public class ConsumerConfigurationTests<K,V> {
 		topicStreamMap.put("topic1", 1);
 		when(consumerMetadata.getTopicStreamMap()).thenReturn(topicStreamMap);
 		when(messageLeftOverTracker.getCurrentCount()).thenReturn(3);
-		final MessageAndMetadata<String, String> m1 = new MessageAndMetadata<String, String>("key1", "value1", "topic1", 1, 1L);
-		final MessageAndMetadata<String, String> m2 = new MessageAndMetadata<String, String>("key2", "value2", "topic2", 1, 1L);
-		final MessageAndMetadata<String, String> m3 = new MessageAndMetadata<String, String>("key1", "value3", "topic3", 1, 1L);
+
+        final MessageAndMetadata<String, String> m1 = mock(MessageAndMetadata.class);
+        final MessageAndMetadata<String, String> m2 = mock(MessageAndMetadata.class);
+        final MessageAndMetadata<String, String> m3 = mock(MessageAndMetadata.class);
+
+        when(m1.key()).thenReturn("key1");
+        when(m1.message()).thenReturn("value1");
+        when(m1.topic()).thenReturn("topic1");
+        when(m1.partition()).thenReturn(1);
+
+        when(m2.key()).thenReturn("key2");
+        when(m2.message()).thenReturn("value2");
+        when(m2.topic()).thenReturn("topic2");
+        when(m2.partition()).thenReturn(1);
+
+        when(m3.key()).thenReturn("key1");
+        when(m3.message()).thenReturn("value3");
+        when(m3.topic()).thenReturn("topic3");
+        when(m3.partition()).thenReturn(1);
 
 		final List<MessageAndMetadata<String, String>> mList = new ArrayList<MessageAndMetadata<String, String>>();
 		mList.add(m1);


### PR DESCRIPTION
Update Kafka version to 0.8.1.1
Perform the necessary API Changes (Partioner interface in Kafka is now non-genericized for Keys - concrete Object is the new type for Key)
Unit test updates for an internal Kafka class (MessageMetadata)
Updates for the samples Kafka project to use the new M2 snapshot, Spring 4.0 Messaging changes, other build related minor changes, etc.
