### PR TITLE
INTEXT-104: Add ability to set order for kafka outbound channel adapter

### DIFF
--- a/samples/kafka/src/main/java/org/springframework/integration/samples/kafka/outbound/UserTransformer.java
+++ b/samples/kafka/src/main/java/org/springframework/integration/samples/kafka/outbound/UserTransformer.java
@@ -1,0 +1,27 @@
+package org.springframework.integration.samples.kafka.outbound;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.integration.samples.kafka.user.User;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.transformer.Transformer;
+import org.springframework.messaging.Message;
+
+/**
+ * @author Soby Chacko
+ */
+public class UserTransformer implements Transformer {
+
+    Log logger = LogFactory.getLog(getClass());
+
+    @Override
+    public Message<?> transform(Message<?> message) {
+        if(message.getPayload().getClass().isAssignableFrom(User.class)) {
+            User user = (User) message.getPayload();
+            user.setFirstName(user.getFirstName().toString()+user.getFirstName());
+            logger.info("user confirmed " + user.getFirstName());
+            return MessageBuilder.withPayload(user).copyHeaders(message.getHeaders()).build();
+        }
+        return message;
+    }
+}

--- a/samples/kafka/src/main/resources/org/springframework/integration/samples/kafka/outbound/kafkaOutboundAdapterParserTests-context.xml
+++ b/samples/kafka/src/main/resources/org/springframework/integration/samples/kafka/outbound/kafkaOutboundAdapterParserTests-context.xml
@@ -1,23 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:int="http://www.springframework.org/schema/integration"
-	xmlns:int-kafka="http://www.springframework.org/schema/integration/kafka"
-	xmlns:task="http://www.springframework.org/schema/task"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration/kafka http://www.springframework.org/schema/integration/kafka/spring-integration-kafka.xsd
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:int="http://www.springframework.org/schema/integration"
+       xmlns:int-kafka="http://www.springframework.org/schema/integration/kafka"
+       xmlns:task="http://www.springframework.org/schema/task"
+       xmlns:int-stream="http://www.springframework.org/schema/integration/stream"
+       xsi:schemaLocation="http://www.springframework.org/schema/integration/kafka http://www.springframework.org/schema/integration/kafka/spring-integration-kafka.xsd
 	http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
 	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd">
+	http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd
+	http://www.springframework.org/schema/integration/stream
+      http://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd">
 
-	<int:channel id="inputToKafka">
-		<int:queue/>
-	</int:channel>
+	<int:publish-subscribe-channel id="inputToKafka"/>
 
 	<int-kafka:outbound-channel-adapter kafka-producer-context-ref="kafkaProducerContext"
 			auto-startup="false"
-			channel="inputToKafka">
-		<int:poller fixed-delay="1000" time-unit="MILLISECONDS" receive-timeout="0" task-executor="taskExecutor"/>
+			channel="inputToKafka"
+            order="1">
 	</int-kafka:outbound-channel-adapter>
+
+    <int-stream:stdout-channel-adapter id="stdout" append-newline="true"/>
+
+    <int:transformer order="0" ref="userTransformer" input-channel="inputToKafka" output-channel="stdout"/>
+
+    <bean id="userTransformer" class="org.springframework.integration.samples.kafka.outbound.UserTransformer"/>
 
 	<task:executor id="taskExecutor" pool-size="5" keep-alive="120" queue-capacity="500"/>
 

--- a/spring-integration-kafka/src/main/resources/org/springframework/integration/config/xml/spring-integration-kafka-1.0.xsd
+++ b/spring-integration-kafka/src/main/resources/org/springframework/integration/config/xml/spring-integration-kafka-1.0.xsd
@@ -504,6 +504,14 @@
                     </xsd:appinfo>
                 </xsd:annotation>
             </xsd:attribute>
+            <xsd:attribute name="order">
+                <xsd:annotation>
+                    <xsd:documentation>
+                        Specifies the order for invocation when this endpoint is connected as a
+                        subscriber to a SubscribableChannel.
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
         </xsd:complexType>
     </xsd:element>
 </xsd:schema>

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundAdapterParserTests-context.xml
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundAdapterParserTests-context.xml
@@ -17,6 +17,7 @@
                                         kafka-producer-context-ref="kafkaProducerContext"
                                         auto-startup="false"
                                         channel="inputToKafka"
+                                        order="3"
             >
         <int:poller fixed-delay="1000" time-unit="MILLISECONDS" receive-timeout="0" task-executor="taskExecutor"/>
     </int-kafka:outbound-channel-adapter>

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundAdapterParserTests.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundAdapterParserTests.java
@@ -44,6 +44,7 @@ public class KafkaOutboundAdapterParserTests<K,V> {
 		final KafkaProducerMessageHandler<K,V> messageHandler = appContext.getBean(KafkaProducerMessageHandler.class);
 		Assert.assertNotNull(pollingConsumer);
 		Assert.assertNotNull(messageHandler);
+        Assert.assertEquals(messageHandler.getOrder(), 3);
 		final KafkaProducerContext<K,V> producerContext = messageHandler.getKafkaProducerContext();
 		Assert.assertNotNull(producerContext);
 		Assert.assertEquals(producerContext.getTopicsConfiguration().size(), 2);


### PR DESCRIPTION
order attribute now honored if kafka outbound adapter is connected to a subscribable channel
unit tests and samples are updated
