### PR TITLE
DSL: Add `File.` Namespace Builder Factory

### DIFF
--- a/spring-integration-java-dsl/src/main/java/org/springframework/integration/dsl/AggregatorSpec.java
+++ b/spring-integration-java-dsl/src/main/java/org/springframework/integration/dsl/AggregatorSpec.java
@@ -17,6 +17,7 @@
 package org.springframework.integration.dsl;
 
 import org.springframework.integration.aggregator.AggregatingMessageHandler;
+import org.springframework.integration.aggregator.DefaultAggregatingMessageGroupProcessor;
 import org.springframework.integration.aggregator.ExpressionEvaluatingMessageGroupProcessor;
 import org.springframework.integration.aggregator.MessageGroupProcessor;
 import org.springframework.integration.aggregator.MethodInvokingMessageGroupProcessor;
@@ -26,7 +27,7 @@ import org.springframework.integration.aggregator.MethodInvokingMessageGroupProc
  */
 public class AggregatorSpec extends CorrelationHandlerSpec<AggregatorSpec, AggregatingMessageHandler> {
 
-	private MessageGroupProcessor outputProcessor;
+	private MessageGroupProcessor outputProcessor = new DefaultAggregatingMessageGroupProcessor();
 
 	private boolean expireGroupsUponCompletion;
 

--- a/spring-integration-java-dsl/src/main/java/org/springframework/integration/dsl/IntegrationFlowBuilder.java
+++ b/spring-integration-java-dsl/src/main/java/org/springframework/integration/dsl/IntegrationFlowBuilder.java
@@ -22,7 +22,6 @@ import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.integration.aggregator.AbstractCorrelatingMessageHandler;
 import org.springframework.integration.aggregator.AggregatingMessageHandler;
-import org.springframework.integration.aggregator.DefaultAggregatingMessageGroupProcessor;
 import org.springframework.integration.aggregator.ResequencingMessageHandler;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.FixedSubscriberChannel;
@@ -91,6 +90,13 @@ public final class IntegrationFlowBuilder {
 
 	IntegrationFlowBuilder addComponent(Object component) {
 		this.flow.addComponent(component);
+		return this;
+	}
+
+	IntegrationFlowBuilder addComponents(Collection<Object> components) {
+		for (Object component : components) {
+			this.flow.addComponent(component);
+		}
 		return this;
 	}
 
@@ -406,8 +412,7 @@ public final class IntegrationFlowBuilder {
 
 	public IntegrationFlowBuilder
 	aggregate(EndpointConfigurer<GenericEndpointSpec<AggregatingMessageHandler>> endpointConfigurer) {
-		return handle(new AggregatorSpec().outputProcessor(new DefaultAggregatingMessageGroupProcessor()).get(),
-				endpointConfigurer);
+		return handle(new AggregatorSpec().get(), endpointConfigurer);
 	}
 
 	public IntegrationFlowBuilder aggregate(ComponentConfigurer<AggregatorSpec> aggregatorConfigurer,

--- a/spring-integration-java-dsl/src/main/java/org/springframework/integration/dsl/core/ComponentsRegistration.java
+++ b/spring-integration-java-dsl/src/main/java/org/springframework/integration/dsl/core/ComponentsRegistration.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.dsl.core;
+
+import java.util.Collection;
+
+/**
+ * @author Artem Bilan
+ */
+public interface ComponentsRegistration {
+
+	Collection<Object> getComponentsToRegister();
+
+}

--- a/spring-integration-java-dsl/src/main/java/org/springframework/integration/dsl/core/ConsumerEndpointSpec.java
+++ b/spring-integration-java-dsl/src/main/java/org/springframework/integration/dsl/core/ConsumerEndpointSpec.java
@@ -23,13 +23,13 @@ import java.util.List;
 import org.aopalliance.aop.Advice;
 
 import org.springframework.integration.config.ConsumerEndpointFactoryBean;
+import org.springframework.integration.handler.AbstractMessageHandler;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.integration.scheduling.PollerMetadata;
 import org.springframework.messaging.MessageHandler;
 
 /**
  * @author Artem Bilan
-
  */
 public abstract class ConsumerEndpointSpec<S extends ConsumerEndpointSpec<S, H>, H extends MessageHandler>
 		extends EndpointSpec<S, ConsumerEndpointFactoryBean, H> {
@@ -85,6 +85,17 @@ public abstract class ConsumerEndpointSpec<S extends ConsumerEndpointSpec<S, H>,
 		}
 		else {
 			logger.warn("'sendTimeout' can be applied only for AbstractReplyProducingMessageHandler");
+		}
+		return _this();
+	}
+
+	public S order(int order) {
+		H handler = this.target.getT2();
+		if (handler instanceof AbstractMessageHandler) {
+			((AbstractMessageHandler) handler).setOrder(order);
+		}
+		else {
+			logger.warn("'order' can be applied only for AbstractMessageHandler");
 		}
 		return _this();
 	}

--- a/spring-integration-java-dsl/src/main/java/org/springframework/integration/dsl/core/IntegrationFlowBeanPostProcessor.java
+++ b/spring-integration-java-dsl/src/main/java/org/springframework/integration/dsl/core/IntegrationFlowBeanPostProcessor.java
@@ -34,6 +34,7 @@ import org.springframework.integration.config.SourcePollingChannelAdapterFactory
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.SourcePollingChannelAdapterSpec;
 import org.springframework.integration.dsl.support.MessageChannelReference;
+import org.springframework.integration.support.context.NamedComponent;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.util.Assert;
@@ -156,6 +157,9 @@ public class IntegrationFlowBeanPostProcessor implements BeanPostProcessor, Bean
 	}
 
 	private String generateBeanName(Object instance) {
+		if (instance instanceof NamedComponent && ((NamedComponent) instance).getComponentName() != null) {
+			return ((NamedComponent) instance).getComponentName();
+		}
 		String generatedBeanName = instance.getClass().getName();
 		String id = instance.getClass().getName();
 		int counter = -1;

--- a/spring-integration-java-dsl/src/main/java/org/springframework/integration/dsl/core/MessagingProducerSpec.java
+++ b/spring-integration-java-dsl/src/main/java/org/springframework/integration/dsl/core/MessagingProducerSpec.java
@@ -55,7 +55,7 @@ public abstract class MessagingProducerSpec<S extends MessagingProducerSpec<S, P
 	}
 
 	@Override
-	protected final P doGet() {
+	protected P doGet() {
 		throw new UnsupportedOperationException();
 	}
 

--- a/spring-integration-java-dsl/src/main/java/org/springframework/integration/dsl/file/File.java
+++ b/spring-integration-java-dsl/src/main/java/org/springframework/integration/dsl/file/File.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.dsl.file;
+
+import java.util.Comparator;
+
+/**
+ * @author Artem Bilan
+ */
+public abstract class File {
+
+	public static FileInboundChannelAdapterSpec inboundAdapter(java.io.File directory) {
+		return inboundAdapter(directory, null);
+	}
+
+	public static FileInboundChannelAdapterSpec inboundAdapter(java.io.File directory,
+			Comparator<java.io.File> receptionOrderComparator) {
+		return new FileInboundChannelAdapterSpec(receptionOrderComparator).directory(directory);
+	}
+
+	public static FileWritingMessageHandlerSpec outboundAdapter(java.io.File destinationDirectory) {
+		return new FileWritingMessageHandlerSpec(destinationDirectory).expectReply(false);
+	}
+
+	public static FileWritingMessageHandlerSpec outboundAdapter(String directoryExpression) {
+		return new FileWritingMessageHandlerSpec(directoryExpression).expectReply(false);
+	}
+
+	public static FileWritingMessageHandlerSpec outboundGateway(java.io.File destinationDirectory) {
+		return new FileWritingMessageHandlerSpec(destinationDirectory).expectReply(true);
+	}
+
+	public static FileWritingMessageHandlerSpec outboundGateway(String directoryExpression) {
+		return new FileWritingMessageHandlerSpec(directoryExpression).expectReply(true);
+	}
+
+	public static TailAdapterSpec tailAdapter(java.io.File file) {
+		return new TailAdapterSpec().file(file);
+	}
+
+}

--- a/spring-integration-java-dsl/src/main/java/org/springframework/integration/dsl/file/FileInboundChannelAdapterSpec.java
+++ b/spring-integration-java-dsl/src/main/java/org/springframework/integration/dsl/file/FileInboundChannelAdapterSpec.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.dsl.file;
+
+import java.io.File;
+import java.util.Comparator;
+
+import org.springframework.integration.dsl.core.MessageSourceSpec;
+import org.springframework.integration.file.DirectoryScanner;
+import org.springframework.integration.file.FileLocker;
+import org.springframework.integration.file.FileReadingMessageSource;
+import org.springframework.integration.file.filters.AcceptAllFileListFilter;
+import org.springframework.integration.file.filters.AcceptOnceFileListFilter;
+import org.springframework.integration.file.filters.CompositeFileListFilter;
+import org.springframework.integration.file.filters.FileListFilter;
+import org.springframework.integration.file.filters.RegexPatternFileListFilter;
+import org.springframework.integration.file.filters.SimplePatternFileListFilter;
+import org.springframework.integration.file.locking.NioFileLocker;
+import org.springframework.util.Assert;
+
+/**
+ * @author Artem Bilan
+ */
+public class FileInboundChannelAdapterSpec
+		extends MessageSourceSpec<FileInboundChannelAdapterSpec, FileReadingMessageSource> {
+
+	private FileListFilter<File> filter;
+
+	private FileLocker locker;
+
+	FileInboundChannelAdapterSpec() {
+		this.target = new FileReadingMessageSource();
+	}
+
+	FileInboundChannelAdapterSpec(Comparator<File> receptionOrderComparator) {
+		this.target = new FileReadingMessageSource(receptionOrderComparator);
+	}
+
+	FileInboundChannelAdapterSpec directory(File directory) {
+		this.target.setDirectory(directory);
+		return _this();
+	}
+
+	public FileInboundChannelAdapterSpec scanner(DirectoryScanner scanner) {
+		this.target.setScanner(scanner);
+		return _this();
+	}
+
+	public FileInboundChannelAdapterSpec autoCreateDirectory(boolean autoCreateDirectory) {
+		this.target.setAutoCreateDirectory(autoCreateDirectory);
+		return _this();
+	}
+
+	public FileInboundChannelAdapterSpec filter(FileListFilter<File> filter) {
+		return filter(filter, false);
+	}
+
+	public FileInboundChannelAdapterSpec filter(FileListFilter<File> filter, boolean preventDuplicates) {
+		Assert.isNull(this.filter,
+				"The 'filter' (" + this.filter + ") is already configured for the FileReadingMessageSource");
+		FileListFilter<File> targetFilter = filter;
+		if (preventDuplicates) {
+			targetFilter = createCompositeWithAcceptOnceFilter(filter);
+		}
+		this.filter = targetFilter;
+		this.target.setFilter(targetFilter);
+		return _this();
+	}
+
+	public FileInboundChannelAdapterSpec preventDuplicatesFilter(boolean preventDuplicates) {
+		if (preventDuplicates) {
+			return filter(new AcceptOnceFileListFilter<File>(), false);
+		}
+		else {
+			return filter(new AcceptAllFileListFilter<File>(), false);
+		}
+	}
+
+	public FileInboundChannelAdapterSpec patternFilter(String pattern) {
+		return patternFilter(pattern, true);
+	}
+
+	public FileInboundChannelAdapterSpec patternFilter(String pattern, boolean preventDuplicates) {
+		return filter(new SimplePatternFileListFilter(pattern), preventDuplicates);
+	}
+
+	public FileInboundChannelAdapterSpec regexFilter(String regex) {
+		return regexFilter(regex, true);
+	}
+
+	public FileInboundChannelAdapterSpec regexFilter(String regex, boolean preventDuplicates) {
+		return filter(new RegexPatternFileListFilter(regex), preventDuplicates);
+	}
+
+	private CompositeFileListFilter<File> createCompositeWithAcceptOnceFilter(FileListFilter<File> otherFilter) {
+		CompositeFileListFilter<File> compositeFilter = new CompositeFileListFilter<File>();
+		compositeFilter.addFilter(new AcceptOnceFileListFilter<File>());
+		compositeFilter.addFilter(otherFilter);
+		return compositeFilter;
+	}
+
+	public FileInboundChannelAdapterSpec locker(FileLocker locker) {
+		Assert.isNull(this.locker,
+				"The 'locker' (" + this.locker + ") is already configured for the FileReadingMessageSource");
+		this.locker = locker;
+		this.target.setLocker(locker);
+		return _this();
+	}
+
+	public FileInboundChannelAdapterSpec nioLocker() {
+		return locker(new NioFileLocker());
+	}
+
+	public FileInboundChannelAdapterSpec scanEachPoll(boolean scanEachPoll) {
+		this.target.setScanEachPoll(scanEachPoll);
+		return _this();
+	}
+
+	@Override
+	protected FileReadingMessageSource doGet() {
+		throw new UnsupportedOperationException();
+	}
+
+}

--- a/spring-integration-java-dsl/src/main/java/org/springframework/integration/dsl/file/FileWritingMessageHandlerSpec.java
+++ b/spring-integration-java-dsl/src/main/java/org/springframework/integration/dsl/file/FileWritingMessageHandlerSpec.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.dsl.file;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.springframework.integration.dsl.core.ComponentsRegistration;
+import org.springframework.integration.dsl.core.MessageHandlerSpec;
+import org.springframework.integration.file.DefaultFileNameGenerator;
+import org.springframework.integration.file.FileNameGenerator;
+import org.springframework.integration.file.FileWritingMessageHandler;
+import org.springframework.integration.file.support.FileExistsMode;
+import org.springframework.util.Assert;
+
+/**
+ * @author Artem Bilan
+ */
+public class FileWritingMessageHandlerSpec
+		extends MessageHandlerSpec<FileWritingMessageHandlerSpec, FileWritingMessageHandler>
+		implements ComponentsRegistration {
+
+	private FileNameGenerator fileNameGenerator;
+
+	private DefaultFileNameGenerator defaultFileNameGenerator;
+
+	FileWritingMessageHandlerSpec(java.io.File destinationDirectory) {
+		this.target = new FileWritingMessageHandler(destinationDirectory);
+	}
+
+	FileWritingMessageHandlerSpec(String directoryExpression) {
+		this.target = new FileWritingMessageHandler(PARSER.parseExpression(directoryExpression));
+	}
+
+	FileWritingMessageHandlerSpec expectReply(boolean expectReply) {
+		target.setExpectReply(expectReply);
+		return _this();
+	}
+
+	public FileWritingMessageHandlerSpec autoCreateDirectory(boolean autoCreateDirectory) {
+		target.setAutoCreateDirectory(autoCreateDirectory);
+		return _this();
+	}
+
+	public FileWritingMessageHandlerSpec temporaryFileSuffix(String temporaryFileSuffix) {
+		target.setTemporaryFileSuffix(temporaryFileSuffix);
+		return _this();
+	}
+
+	public FileWritingMessageHandlerSpec fileExistsMode(FileExistsMode fileExistsMode) {
+		target.setFileExistsMode(fileExistsMode);
+		return _this();
+	}
+
+	public FileWritingMessageHandlerSpec fileNameGenerator(FileNameGenerator fileNameGenerator) {
+		this.fileNameGenerator = fileNameGenerator;
+		target.setFileNameGenerator(fileNameGenerator);
+		return _this();
+	}
+
+	public FileWritingMessageHandlerSpec fileNameGeneratorExpression(String fileNameGeneratorExpression) {
+		Assert.isNull(this.fileNameGenerator,
+				"'fileNameGenerator' and 'fileNameGeneratorExpression' are mutually exclusive.");
+		this.defaultFileNameGenerator = new DefaultFileNameGenerator();
+		this.defaultFileNameGenerator.setExpression(fileNameGeneratorExpression);
+		return _this();
+	}
+
+
+	public FileWritingMessageHandlerSpec deleteSourceFiles(boolean deleteSourceFiles) {
+		target.setDeleteSourceFiles(deleteSourceFiles);
+		return _this();
+	}
+
+	public FileWritingMessageHandlerSpec charset(String charset) {
+		target.setCharset(charset);
+		return _this();
+	}
+
+	@Override
+	public Collection<Object> getComponentsToRegister() {
+		if (this.defaultFileNameGenerator != null) {
+			return Collections.<Object>singletonList(this.defaultFileNameGenerator);
+		}
+		return Collections.<Object>emptyList();
+	}
+
+	@Override
+	protected FileWritingMessageHandler doGet() {
+		throw new UnsupportedOperationException();
+	}
+
+}

--- a/spring-integration-java-dsl/src/main/java/org/springframework/integration/dsl/file/TailAdapterSpec.java
+++ b/spring-integration-java-dsl/src/main/java/org/springframework/integration/dsl/file/TailAdapterSpec.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.dsl.file;
+
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.integration.channel.NullChannel;
+import org.springframework.integration.dsl.core.MessagingProducerSpec;
+import org.springframework.integration.file.config.FileTailInboundChannelAdapterFactoryBean;
+import org.springframework.integration.file.tail.FileTailingMessageProducerSupport;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.util.Assert;
+
+/**
+ * @author Artem Bilan
+ */
+public class TailAdapterSpec extends MessagingProducerSpec<TailAdapterSpec, FileTailingMessageProducerSupport> {
+
+	private final FileTailInboundChannelAdapterFactoryBean factoryBean = new FileTailInboundChannelAdapterFactoryBean();
+
+	private MessageChannel outputChannel;
+
+	private MessageChannel errorChannel;
+
+	TailAdapterSpec() {
+		super(null);
+		this.factoryBean.setBeanFactory(new DefaultListableBeanFactory());
+	}
+
+	TailAdapterSpec file(java.io.File file) {
+		Assert.notNull(file);
+		this.factoryBean.setFile(file);
+		return _this();
+	}
+
+	public TailAdapterSpec nativeOptions(String nativeOptions) {
+		this.factoryBean.setNativeOptions(nativeOptions);
+		return _this();
+	}
+
+	public TailAdapterSpec taskExecutor(TaskExecutor taskExecutor) {
+		this.factoryBean.setTaskExecutor(taskExecutor);
+		return _this();
+	}
+
+	public TailAdapterSpec taskScheduler(TaskScheduler taskScheduler) {
+		this.factoryBean.setTaskScheduler(taskScheduler);
+		return _this();
+	}
+
+	public TailAdapterSpec delay(long delay) {
+		this.factoryBean.setDelay(delay);
+		return _this();
+	}
+
+	public TailAdapterSpec fileDelay(long fileDelay) {
+		this.factoryBean.setFileDelay(fileDelay);
+		return _this();
+	}
+
+	public TailAdapterSpec end(boolean end) {
+		this.factoryBean.setEnd(end);
+		return _this();
+	}
+
+	public TailAdapterSpec reopen(boolean reopen) {
+		this.factoryBean.setReopen(reopen);
+		return _this();
+	}
+
+	@Override
+	public TailAdapterSpec id(String id) {
+		this.factoryBean.setBeanName(id);
+		return _this();
+	}
+
+	@Override
+	public TailAdapterSpec phase(int phase) {
+		this.factoryBean.setPhase(phase);
+		return _this();
+	}
+
+	@Override
+	public TailAdapterSpec autoStartup(boolean autoStartup) {
+		this.factoryBean.setAutoStartup(autoStartup);
+		return _this();
+	}
+
+	@Override
+	public TailAdapterSpec outputChannel(MessageChannel outputChannel) {
+		this.outputChannel = outputChannel;
+		return _this();
+	}
+
+	@Override
+	public TailAdapterSpec errorChannel(MessageChannel errorChannel) {
+		this.errorChannel = errorChannel;
+		return _this();
+	}
+
+	@Override
+	protected FileTailingMessageProducerSupport doGet() {
+		if (this.outputChannel == null) {
+			this.factoryBean.setOutputChannel(new NullChannel());
+		}
+		FileTailingMessageProducerSupport tailingMessageProducerSupport = null;
+		try {
+			this.factoryBean.afterPropertiesSet();
+			tailingMessageProducerSupport = this.factoryBean.getObject();
+		}
+		catch (Exception e) {
+			throw new IllegalStateException(e);
+		}
+		if (this.errorChannel != null) {
+			tailingMessageProducerSupport.setErrorChannel(this.errorChannel);
+		}
+		tailingMessageProducerSupport.setOutputChannel(this.outputChannel);
+		return tailingMessageProducerSupport;
+	}
+
+}

--- a/spring-integration-java-dsl/src/main/java/org/springframework/integration/dsl/file/package-info.java
+++ b/spring-integration-java-dsl/src/main/java/org/springframework/integration/dsl/file/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Provides File Components support for Spring Integration Java DSL.
+ */
+package org.springframework.integration.dsl.file;


### PR DESCRIPTION
- Introduce `ComponentsRegistration` _marker_ to extract internal components from the `IntegrationComponentSpec` to be registered as bean in the application context
- Add `ConsumerEndpointSpec#order(int order)` for the `order` of target `AbstractMessageHandler`
- Fix `AggregatorSpec` to use `DefaultAggregatingMessageGroupProcessor` by default
- Fix `IntegrationFlowBeanPostProcessor#generateBeanName` to check if `instance instanceof NamedComponent` and its `beanName` has been configured
  using `IntegrationComponentSpec#id`
