### PR TITLE
Update EnricherSpec.java

### DIFF
--- a/spring-integration-java-dsl/src/main/java/org/springframework/integration/dsl/EnricherSpec.java
+++ b/spring-integration-java-dsl/src/main/java/org/springframework/integration/dsl/EnricherSpec.java
@@ -129,7 +129,9 @@ public class EnricherSpec extends MessageHandlerSpec<EnricherSpec, ContentEnrich
 	@Override
 	protected ContentEnricher doGet() {
 		this.enricher.setPropertyExpressions(this.propertyExpressions);
-		this.enricher.setHeaderExpressions(this.headerExpressions);
+		if(!this.headerExpressions.isEmpty()) {
+			this.enricher.setHeaderExpressions(this.headerExpressions);
+		}
 		return this.enricher;
 	}
 


### PR DESCRIPTION
If we don't add a header expression (because we simply only want to enrich the payload), we will get an assertion error in the ContentEnricher class saying "headerExpressions must not be empty".
