### PR TITLE
Java DSL: Assertion error "headerExpressions must not be empty"

### DIFF
--- a/spring-integration-java-dsl/src/main/java/org/springframework/integration/dsl/EnricherSpec.java
+++ b/spring-integration-java-dsl/src/main/java/org/springframework/integration/dsl/EnricherSpec.java
@@ -33,6 +33,7 @@ import org.springframework.util.Assert;
 
 /**
  * @author Artem Bilan
+ * @author Tim Ysewyn
  */
 public class EnricherSpec extends MessageHandlerSpec<EnricherSpec, ContentEnricher> {
 
@@ -128,8 +129,12 @@ public class EnricherSpec extends MessageHandlerSpec<EnricherSpec, ContentEnrich
 
 	@Override
 	protected ContentEnricher doGet() {
-		this.enricher.setPropertyExpressions(this.propertyExpressions);
-		this.enricher.setHeaderExpressions(this.headerExpressions);
+		if(!this.propertyExpressions.isEmpty()) {
+			this.enricher.setPropertyExpressions(this.propertyExpressions);
+		}
+		if(!this.headerExpressions.isEmpty()) {
+			this.enricher.setHeaderExpressions(this.headerExpressions);
+		}
 		return this.enricher;
 	}
 


### PR DESCRIPTION
Fix for spring-projects#101

If we don't add a `headerExpression` on the `EnricherSpec` class (because we simply only want to enrich the payload), we will get an assertion error in the `ContentEnricher` class saying 

```
headerExpressions must not be empty
```

The is also the same when we only want to use header expressions.

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.
