### PR TITLE
DSL: Mail Polish - Add SearchTerm (lambda) To Test

### DIFF
--- a/spring-integration-java-dsl/src/test/java/org/springframework/integration/dsl/test/mail/MailTests.java
+++ b/spring-integration-java-dsl/src/test/java/org/springframework/integration/dsl/test/mail/MailTests.java
@@ -24,8 +24,11 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Properties;
 
+import javax.mail.internet.AddressException;
+import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMessage.RecipientType;
+import javax.mail.search.FromTerm;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -190,11 +193,21 @@ public class MailTests {
 		public IntegrationFlow imapMailFlow() {
 			return IntegrationFlows
 					.from(Mail.imapInboundAdapter("imap://user:pw@localhost:" + imapPort + "/INBOX")
+									.searchTermStrategy((f,l) -> new FromTerm(fromAddress()))
 									.javaMailProperties(p -> p.put("mail.debug", "true")),
 							e -> e.autoStartup(true)
 									.poller(Pollers.fixedDelay(1000)))
 					.channel(MessageChannels.queue("imapChannel"))
 					.get();
+		}
+
+		private InternetAddress fromAddress() {
+			try {
+				return new InternetAddress("bar@baz");
+			}
+			catch (AddressException e) {
+				throw new RuntimeException(e);
+			}
 		}
 
 	}

--- a/spring-integration-java-dsl/src/test/java/org/springframework/integration/dsl/test/mail/PoorMansMailServer.java
+++ b/spring-integration-java-dsl/src/test/java/org/springframework/integration/dsl/test/mail/PoorMansMailServer.java
@@ -209,12 +209,12 @@ public class PoorMansMailServer {
 
 		@Override
 		protected MailHandler mailHandler(Socket socket) {
-			return new Pop3Handler(socket);
+			return new ImapHandler(socket);
 		}
 
-		public class Pop3Handler extends MailHandler {
+		public class ImapHandler extends MailHandler {
 
-			public Pop3Handler(Socket socket) {
+			public ImapHandler(Socket socket) {
 				super(socket);
 			}
 
@@ -246,7 +246,7 @@ public class PoorMansMailServer {
 							write("* OK [UNSEEN 1]");
 							write(tag + "OK EXAMINE completed");
 						}
-						else if (line.endsWith("SEARCH NOT (FLAGGED) ALL")) {
+						else if (line.endsWith("SEARCH FROM bar@baz ALL")) {
 							write("* SEARCH 1 1");
 							write(tag + "OK SEARCH completed");
 						}


### PR DESCRIPTION
Perhaps in a future enhancement, we can add helper methods to `Mail` to construct search terms.

e.g.

```
 .searchTermStrategy((f,l) -> Mail.from("foo@bar"))
```
