### PR TITLE
DSL: Fix `RouterSpec` for several subflows

### DIFF
--- a/spring-integration-java-dsl/src/main/java/org/springframework/integration/dsl/RouterSpec.java
+++ b/spring-integration-java-dsl/src/main/java/org/springframework/integration/dsl/RouterSpec.java
@@ -90,7 +90,6 @@ public final class RouterSpec<R extends AbstractMappingMessageRouter> extends Ab
 
 		if (this.mappingProvider == null) {
 			this.mappingProvider = new RouterSubFlowMappingProvider(this.target);
-			this.subFlows.add(this.mappingProvider);
 		}
 		this.mappingProvider.addMapping(key, channel);
 		return _this();
@@ -98,6 +97,9 @@ public final class RouterSpec<R extends AbstractMappingMessageRouter> extends Ab
 
 	@Override
 	public Collection<Object> getComponentsToRegister() {
+		if (this.mappingProvider != null) {
+			this.subFlows.add(this.mappingProvider);
+		}
 		return this.subFlows;
 	}
 


### PR DESCRIPTION
The root if issue is up to the order of bean registration in the beanFactory.
In this case the first subflows is registered correctly, but the next on has been registered after `RouterSubFlowMappingProvider`.
In this case the input `channel` of the next subflow hasn't been registered yet, hence `NPE` in the `this.router.setChannelMapping`
from `@PostConstruct` of `RouterSubFlowMappingProvider`.

Move the `RouterSubFlowMappingProvider` to end of `commentsToRegister` collection to give a chance to register all subflows before the `RouterSubFlowMappingProvider`
