### PR TITLE
DSL: O-Gs: `requiresReply="true"` by default

### DIFF
--- a/spring-integration-java-dsl/src/main/java/org/springframework/integration/dsl/amqp/AmqpOutboundEndpointSpec.java
+++ b/spring-integration-java-dsl/src/main/java/org/springframework/integration/dsl/amqp/AmqpOutboundEndpointSpec.java
@@ -40,6 +40,9 @@ public class AmqpOutboundEndpointSpec extends MessageHandlerSpec<AmqpOutboundEnd
 		this.endpoint = new AmqpOutboundEndpoint(amqpTemplate);
 		this.expectReply = expectReply;
 		this.endpoint.setExpectReply(expectReply);
+		if (expectReply) {
+			this.endpoint.setRequiresReply(true);
+		}
 		this.endpoint.setHeaderMapper(this.headerMapper);
 	}
 

--- a/spring-integration-java-dsl/src/main/java/org/springframework/integration/dsl/file/FileWritingMessageHandlerSpec.java
+++ b/spring-integration-java-dsl/src/main/java/org/springframework/integration/dsl/file/FileWritingMessageHandlerSpec.java
@@ -55,28 +55,31 @@ public class FileWritingMessageHandlerSpec
 	}
 
 	FileWritingMessageHandlerSpec expectReply(boolean expectReply) {
-		target.setExpectReply(expectReply);
+		this.target.setExpectReply(expectReply);
+		if (expectReply) {
+			this.target.setRequiresReply(true);
+		}
 		return _this();
 	}
 
 	public FileWritingMessageHandlerSpec autoCreateDirectory(boolean autoCreateDirectory) {
-		target.setAutoCreateDirectory(autoCreateDirectory);
+		this.target.setAutoCreateDirectory(autoCreateDirectory);
 		return _this();
 	}
 
 	public FileWritingMessageHandlerSpec temporaryFileSuffix(String temporaryFileSuffix) {
-		target.setTemporaryFileSuffix(temporaryFileSuffix);
+		this.target.setTemporaryFileSuffix(temporaryFileSuffix);
 		return _this();
 	}
 
 	public FileWritingMessageHandlerSpec fileExistsMode(FileExistsMode fileExistsMode) {
-		target.setFileExistsMode(fileExistsMode);
+		this.target.setFileExistsMode(fileExistsMode);
 		return _this();
 	}
 
 	public FileWritingMessageHandlerSpec fileNameGenerator(FileNameGenerator fileNameGenerator) {
 		this.fileNameGenerator = fileNameGenerator;
-		target.setFileNameGenerator(fileNameGenerator);
+		this.target.setFileNameGenerator(fileNameGenerator);
 		return _this();
 	}
 
@@ -90,12 +93,12 @@ public class FileWritingMessageHandlerSpec
 
 
 	public FileWritingMessageHandlerSpec deleteSourceFiles(boolean deleteSourceFiles) {
-		target.setDeleteSourceFiles(deleteSourceFiles);
+		this.target.setDeleteSourceFiles(deleteSourceFiles);
 		return _this();
 	}
 
 	public FileWritingMessageHandlerSpec charset(String charset) {
-		target.setCharset(charset);
+		this.target.setCharset(charset);
 		return _this();
 	}
 

--- a/spring-integration-java-dsl/src/main/java/org/springframework/integration/dsl/file/RemoteFileOutboundGatewaySpec.java
+++ b/spring-integration-java-dsl/src/main/java/org/springframework/integration/dsl/file/RemoteFileOutboundGatewaySpec.java
@@ -40,6 +40,7 @@ public abstract class RemoteFileOutboundGatewaySpec<F, S extends RemoteFileOutbo
 
 	protected RemoteFileOutboundGatewaySpec(AbstractRemoteFileOutboundGateway<F> outboundGateway) {
 		this.target = outboundGateway;
+		this.target.setRequiresReply(true);
 	}
 
 	public S options(String options) {

--- a/spring-integration-java-dsl/src/main/java/org/springframework/integration/dsl/jms/JmsOutboundGatewaySpec.java
+++ b/spring-integration-java-dsl/src/main/java/org/springframework/integration/dsl/jms/JmsOutboundGatewaySpec.java
@@ -41,6 +41,7 @@ public class JmsOutboundGatewaySpec extends MessageHandlerSpec<JmsOutboundGatewa
 	JmsOutboundGatewaySpec(ConnectionFactory connectionFactory) {
 		this.target = new JmsOutboundGateway();
 		this.target.setConnectionFactory(connectionFactory);
+		this.target.setRequiresReply(true);
 	}
 
 	public JmsOutboundGatewaySpec extractRequestPayload(boolean extractPayload) {


### PR DESCRIPTION
Since many `outbound-gateway`s are designed to always expect replies and XML configuration
specifies `requires-reply="true"` for them by default, the DSL should follow with that.
