### PR TITLE
INTEXT-122: Make XSD versionless from SI-core XSD

### DIFF
--- a/spring-integration-smpp/build.gradle
+++ b/spring-integration-smpp/build.gradle
@@ -29,7 +29,7 @@ ext {
 	slf4jVersion = '1.7.7'
 	commonsLangVersion = '2.6'
 	commonsBeanUtilsVersion = '1.8.3'
-	springIntegrationVersion = '4.0.2.RELEASE'
+	springIntegrationVersion = '4.0.5.RELEASE'
 
 	idPrefix = 'smpp'
 

--- a/spring-integration-smpp/src/main/resources/org/springframework/integration/smpp/config/xml/spring-integration-smpp-1.0.xsd
+++ b/spring-integration-smpp/src/main/resources/org/springframework/integration/smpp/config/xml/spring-integration-smpp-1.0.xsd
@@ -10,7 +10,7 @@
 	<xsd:import namespace="http://www.springframework.org/schema/beans" />
 	<xsd:import namespace="http://www.springframework.org/schema/tool" />
 	<xsd:import namespace="http://www.springframework.org/schema/integration"
-		schemaLocation="http://www.springframework.org/schema/integration/spring-integration-4.0.xsd" />
+		schemaLocation="http://www.springframework.org/schema/integration/spring-integration.xsd" />
 
 	<xsd:annotation>
 		<xsd:documentation><![CDATA[


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INTEXT-122

Fix for SMPP. All other extensions will be fixed on demand, when they will be upgraded to SI 4.0 or higher

Tested with SI 4.1
