### PR TITLE
INTEXT-150 - Extract Hazelcast Headers and Payloads

### DIFF
--- a/spring-integration-hazelcast/README.md
+++ b/spring-integration-hazelcast/README.md
@@ -37,7 +37,7 @@ Basically, Hazelcast Event-Driven Inbound Channel Adapter requires following att
 3. Supported cache event types for IList, ISet and IQueue : ADDED, REMOVED. 
 4. There is no need to cache event type definition for ITopic. 
 
-* **cache-listening-policy :** Specifies cache listening policy as SINGLE or ALL. It is optional attribute and its default value is SINGLE. Each Hazelcast inbound channel adapter which listens same cache object with same cache-events attribute, can receive a single event message or all event messages. If this is ALL, all Hazelcast inbound channel adapters which listens same cache object with same cache-events attribute, will receive same event messages. If this is SINGLE, they will receive unique event messages.
+* **cache-listening-policy :** Specifies cache listening policy as SINGLE or ALL. It is optional attribute and its default value is SINGLE. Each Hazelcast CQ inbound channel adapter listening same cache object with same cache-events attribute, can receive a single event message or all event messages. If it is ALL, all Hazelcast CQ inbound channel adapters listening same cache object with same cache-events attribute, will receive same event messages. If it is SINGLE, they will receive unique event messages.
 
 Sample namespace and schemaLocation definitions are as follows : 
 ```
@@ -74,9 +74,7 @@ Sample definitions are as follows :
 
 <int-hazelcast:inbound-channel-adapter channel="multiMapChannel" 
 					          cache="multiMap" 
-					          cache-events="ADDED, 
-							            REMOVED, 
-							            CLEAR_ALL" /> 
+					          cache-events="ADDED, REMOVED, CLEAR_ALL" /> 
 
 <bean id="multiMap" factory-bean="instance" factory-method="getMultiMap"> 
 	<constructor-arg value="multiMap"/> 
@@ -139,7 +137,7 @@ Sample definitions are as follows :
 
 <int-hazelcast:inbound-channel-adapter channel="replicatedMapChannel" 
 					          cache="replicatedMap" 
-					          cache-events="ADDED,UPDATED, REMOVED"
+					          cache-events="ADDED, UPDATED, REMOVED"
  					          cache-listening-policy="SINGLE"  /> 
 
 <bean id="replicatedMap" factory-bean="instance" factory-method="getReplicatedMap"> 
@@ -163,14 +161,18 @@ Hazelcast Continuous Query enables to listen to the modifications performed on s
 				channel="cqMapChannel" 
 				cache="cqMap" 
 				cache-events="UPDATED, REMOVED" 
-				predicate="name=TestName AND surname=TestSurname" /> 
+				predicate="name=TestName AND surname=TestSurname"
+				include-value="true"
+				cache-listening-policy="SINGLE" /> 
 ```
 Basically, it requires four attributes as follows : 
 
 * **channel :** Specifies channel which message is sent. It is mandatory attribute. 
 * **cache :** Specifies distributed Map reference which is listened. It is mandatory attribute. 
 * **cache-events :** Specifies cache events which are listened. It is optional attribute with ADDED default value. Supported values are ADDED, REMOVED, UPDATED, EVICTED, EVICT_ALL and CLEAR_ALL. 
-* **predicate :** Specifies predicate to listen to the modifications performed on specific map entries. It is mandatory attribute. 
+* **predicate :** Specifies predicate to listen to the modifications performed on specific map entries. It is mandatory attribute.
+* **include-value :** Specifies including of value and oldValue in continuous query result. It is optional attribute with 'true' default value.
+* **cache-listening-policy :** Specifies cache listening policy as SINGLE or ALL. It is optional attribute and its default value is SINGLE. Each Hazelcast CQ inbound channel adapter listening same cache object with same cache-events attribute, can receive a single event message or all event messages. If it is ALL, all Hazelcast CQ inbound channel adapters listening same cache object with same cache-events attribute, will receive same event messages. If it is SINGLE, they will receive unique event messages.
 
 Sample definition is as follows : 
 ```
@@ -180,7 +182,9 @@ Sample definition is as follows :
 				channel="cqMapChannel" 
 				cache="cqMap" 
 				cache-events="UPDATED, REMOVED" 
-				predicate="name=TestName AND surname=TestSurname"/> 
+				predicate="name=TestName AND surname=TestSurname"
+				include-value="true"
+				cache-listening-policy="SINGLE"/> 
 
 <bean id="cqMap" factory-bean="instance" factory-method="getMap"> 
 	<constructor-arg value="cqMap"/> 
@@ -205,7 +209,7 @@ Hazelcast allows to run distributed queries on the distributed map. Hazelcast Di
 			     cache="dsMap"
  			     iteration-type="ENTRY" 
                  distributed-sql="active=false OR age >= 25 OR name = 'TestName'"> 
-	<int:poller cron="*/10 * * * * *"/> 
+	<int:poller fixed-delay="100"/>
 </int-hazelcast:ds-inbound-channel-adapter> 
 ```
 Basically, it requires a poller and four attributes such as 
@@ -224,7 +228,7 @@ Sample definition is as follows :
 			cache="dsMap" 
 			iteration-type="ENTRY" 
 			distributed-sql="active=false OR age >= 25 OR name = 'TestName'"> 
-	<int:poller cron="*/10 * * * * *"/> 
+	<int:poller fixed-delay="100"/>
 </int-hazelcast:ds-inbound-channel-adapter> 
 
 <bean id="dsMap" factory-bean="instance" factory-method="getMap"> 

--- a/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/CacheEventType.java
+++ b/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/CacheEventType.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.integration.hazelcast.common;
+package org.springframework.integration.hazelcast;
 
 /**
  * Enumeration of Cache Event Types

--- a/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/CacheListeningPolicyType.java
+++ b/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/CacheListeningPolicyType.java
@@ -13,23 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.integration.hazelcast.message;
+
+package org.springframework.integration.hazelcast;
 
 /**
- * Hazelcast Message Headers
+ * Enumeration of Cache Listening Policy Type
  *
  * @author Eren Avsarogullari
  * @since 1.0.0
+ * @see org.springframework.integration.hazelcast.inbound.AbstractHazelcastMessageProducer
  */
-public abstract class HazelcastHeaders {
+public enum CacheListeningPolicyType {
 
-	private static final String PREFIX = "hazelcast_";
+	SINGLE, ALL;
 
-	public static final String EVENT = PREFIX + "event";
-
-	public static final String MEMBER = PREFIX + "member";
-
-	public static final String NAME = PREFIX + "name";
-
-	public static final String PUBLISHING_TIME = PREFIX + "publishingTime";
 }

--- a/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/DistributedSQLIterationType.java
+++ b/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/DistributedSQLIterationType.java
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-package org.springframework.integration.hazelcast.common;
+package org.springframework.integration.hazelcast;
 
 /**
- * Enumeration of Cache Listening Policy Type
+ * Enumeration of Distributed SQL Iteration Type
  *
  * @author Eren Avsarogullari
  * @since 1.0.0
- * @see org.springframework.integration.hazelcast.inbound.AbstractHazelcastMessageProducer
+ * @see org.springframework.integration.hazelcast.inbound.HazelcastDistributedSQLMessageSource
  */
-public enum CacheListeningPolicyType {
+public enum DistributedSQLIterationType {
 
-	SINGLE, ALL;
+	ENTRY, KEY, LOCAL_KEY, VALUE
 
 }

--- a/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/HazelcastHeaders.java
+++ b/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/HazelcastHeaders.java
@@ -13,18 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-package org.springframework.integration.hazelcast.common;
+package org.springframework.integration.hazelcast;
 
 /**
- * Enumeration of Distributed SQL Iteration Type
+ * Hazelcast Message Headers
  *
  * @author Eren Avsarogullari
  * @since 1.0.0
- * @see org.springframework.integration.hazelcast.inbound.HazelcastDistributedSQLMessageSource
  */
-public enum DistributedSQLIterationType {
+public abstract class HazelcastHeaders {
 
-	ENTRY, KEY, LOCAL_KEY, VALUE
+	private static final String PREFIX = "hazelcast_";
 
+	public static final String EVENT_TYPE = PREFIX + "eventType";
+
+	public static final String MEMBER = PREFIX + "member";
+
+	public static final String CACHE_NAME = PREFIX + "cacheName";
+
+	public static final String PUBLISHING_TIME = PREFIX + "publishingTime";
 }

--- a/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/HazelcastIntegrationDefinitionValidator.java
+++ b/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/HazelcastIntegrationDefinitionValidator.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.integration.hazelcast.common;
+package org.springframework.integration.hazelcast;
 
 import java.util.Arrays;
 import java.util.List;

--- a/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/HazelcastLocalInstanceRegistrar.java
+++ b/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/HazelcastLocalInstanceRegistrar.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.integration.hazelcast.common;
+package org.springframework.integration.hazelcast;
 
 import java.net.SocketAddress;
 import java.util.concurrent.locks.Lock;

--- a/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/common/HazelcastIntegrationDefinitionValidator.java
+++ b/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/common/HazelcastIntegrationDefinitionValidator.java
@@ -20,6 +20,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
+import reactor.util.CollectionUtils;
+import reactor.util.StringUtils;
+
 import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.IList;
 import com.hazelcast.core.IMap;
@@ -28,9 +31,6 @@ import com.hazelcast.core.ISet;
 import com.hazelcast.core.ITopic;
 import com.hazelcast.core.MultiMap;
 import com.hazelcast.core.ReplicatedMap;
-
-import reactor.util.CollectionUtils;
-import reactor.util.StringUtils;
 
 /**
  * Common Validator for Hazelcast Integration. It validates cache types and events.

--- a/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/common/package-info.java
+++ b/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/common/package-info.java
@@ -1,4 +1,0 @@
-/**
- * Provides common used types and classes.
- */
-package org.springframework.integration.hazelcast.common;

--- a/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/config/HazelcastIntegrationConfigurationInitializer.java
+++ b/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/config/HazelcastIntegrationConfigurationInitializer.java
@@ -21,7 +21,7 @@ import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.integration.config.IntegrationConfigurationInitializer;
-import org.springframework.integration.hazelcast.common.HazelcastLocalInstanceRegistrar;
+import org.springframework.integration.hazelcast.HazelcastLocalInstanceRegistrar;
 
 /**
  * The Hazelcast Integration infrastructure {@code beanFactory} initializer.

--- a/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/inbound/AbstractHazelcastMessageProducer.java
+++ b/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/inbound/AbstractHazelcastMessageProducer.java
@@ -20,7 +20,9 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Collections;
 import java.util.EventObject;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import org.springframework.integration.endpoint.MessageProducerSupport;
@@ -28,7 +30,12 @@ import org.springframework.integration.hazelcast.common.CacheEventType;
 import org.springframework.integration.hazelcast.common.CacheListeningPolicyType;
 import org.springframework.integration.hazelcast.common.HazelcastIntegrationDefinitionValidator;
 import org.springframework.integration.hazelcast.common.HazelcastLocalInstanceRegistrar;
+import org.springframework.integration.hazelcast.message.EntryEventMessagePayload;
+import org.springframework.integration.hazelcast.message.HazelcastHeaders;
+import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
+
+import reactor.util.StringUtils;
 
 import com.hazelcast.core.AbstractIMapEvent;
 import com.hazelcast.core.DistributedObject;
@@ -38,8 +45,6 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.MapEvent;
 import com.hazelcast.core.MultiMap;
-
-import reactor.util.StringUtils;
 
 /**
  * Hazelcast Base Event-Driven Message Producer.
@@ -96,10 +101,12 @@ public abstract class AbstractHazelcastMessageProducer extends MessageProducerSu
 
 		protected abstract void processEvent(EventObject event);
 
+		protected abstract Message<?> toMessage(EventObject event);
+
 		protected void sendMessage(final EventObject event, final InetSocketAddress socketAddress,
 				final CacheListeningPolicyType cacheListeningPolicyType) {
 			if (CacheListeningPolicyType.ALL == cacheListeningPolicyType || isEventAcceptable(socketAddress)) {
-				AbstractHazelcastMessageProducer.this.sendMessage(getMessageBuilderFactory().withPayload(event).build());
+				AbstractHazelcastMessageProducer.this.sendMessage(toMessage(event));
 			}
 		}
 
@@ -184,6 +191,31 @@ public abstract class AbstractHazelcastMessageProducer extends MessageProducerSu
 			if (logger.isDebugEnabled()) {
 				logger.debug("Received Event : " + event);
 			}
+		}
+
+		@SuppressWarnings({ "rawtypes", "unchecked" })
+		@Override
+		protected Message<?> toMessage(EventObject event) {
+			EntryEventMessagePayload<?, ?> messagePayload = null;
+
+			final Map<String, Object> headers = new HashMap<String, Object>();
+			headers.put(HazelcastHeaders.EVENT, ((AbstractIMapEvent) event).getEventType());
+			headers.put(HazelcastHeaders.MEMBER, ((AbstractIMapEvent) event).getMember());
+			headers.put(HazelcastHeaders.NAME, ((AbstractIMapEvent) event).getName());
+
+			if (event instanceof EntryEvent) {
+				Assert.notNull(((EntryEvent) event).getKey(), "key must not be null");
+				messagePayload = new EntryEventMessagePayload(
+						((EntryEvent) event).getKey(), ((EntryEvent) event).getValue(),
+						((EntryEvent) event).getOldValue());
+			}
+			else if (event instanceof MapEvent) {
+				messagePayload = new EntryEventMessagePayload(((MapEvent) event).getNumberOfEntriesAffected());
+			} else {
+				throw new IllegalStateException("Invalid event is received. Event : " + event);
+			}
+
+			return getMessageBuilderFactory().withPayload(messagePayload).copyHeaders(headers).build();
 		}
 
 	}

--- a/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/inbound/HazelcastDistributedSQLMessageSource.java
+++ b/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/inbound/HazelcastDistributedSQLMessageSource.java
@@ -20,7 +20,7 @@ import java.util.Collection;
 import java.util.Collections;
 
 import org.springframework.integration.endpoint.AbstractMessageSource;
-import org.springframework.integration.hazelcast.common.DistributedSQLIterationType;
+import org.springframework.integration.hazelcast.DistributedSQLIterationType;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 

--- a/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/inbound/HazelcastEventDrivenMessageProducer.java
+++ b/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/inbound/HazelcastEventDrivenMessageProducer.java
@@ -20,8 +20,8 @@ import java.util.EventObject;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.springframework.integration.hazelcast.common.HazelcastIntegrationDefinitionValidator;
-import org.springframework.integration.hazelcast.message.HazelcastHeaders;
+import org.springframework.integration.hazelcast.HazelcastHeaders;
+import org.springframework.integration.hazelcast.HazelcastIntegrationDefinitionValidator;
 import org.springframework.util.Assert;
 
 import com.hazelcast.core.DistributedObject;
@@ -153,8 +153,8 @@ public class HazelcastEventDrivenMessageProducer extends AbstractHazelcastMessag
 			Assert.notNull(itemEvent.getItem(), "item must not be null");
 
 			final Map<String, Object> headers = new HashMap<String, Object>();
-			headers.put(HazelcastHeaders.EVENT, itemEvent.getEventType());
-			headers.put(HazelcastHeaders.MEMBER, itemEvent.getMember());
+			headers.put(HazelcastHeaders.EVENT_TYPE, itemEvent.getEventType().name());
+			headers.put(HazelcastHeaders.MEMBER, itemEvent.getMember().getSocketAddress());
 
 			return getMessageBuilderFactory().withPayload(itemEvent.getItem()).copyHeaders(headers).build();
 		}
@@ -184,8 +184,8 @@ public class HazelcastEventDrivenMessageProducer extends AbstractHazelcastMessag
 			Assert.notNull(message.getMessageObject(), "message must not be null");
 
 			final Map<String, Object> headers = new HashMap<String, Object>();
-			headers.put(HazelcastHeaders.MEMBER, message.getPublishingMember());
-			headers.put(HazelcastHeaders.NAME, message.getSource());
+			headers.put(HazelcastHeaders.MEMBER, message.getPublishingMember().getSocketAddress());
+			headers.put(HazelcastHeaders.CACHE_NAME, message.getSource());
 			headers.put(HazelcastHeaders.PUBLISHING_TIME, message.getPublishTime());
 
 			return getMessageBuilderFactory().withPayload(message.getMessageObject()).copyHeaders(headers).build();

--- a/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/listener/HazelcastMembershipListener.java
+++ b/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/listener/HazelcastMembershipListener.java
@@ -20,7 +20,7 @@ import java.net.SocketAddress;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
 
-import org.springframework.integration.hazelcast.common.HazelcastLocalInstanceRegistrar;
+import org.springframework.integration.hazelcast.HazelcastLocalInstanceRegistrar;
 
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;

--- a/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/message/EntryEventMessagePayload.java
+++ b/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/message/EntryEventMessagePayload.java
@@ -25,39 +25,64 @@ import org.springframework.util.Assert;
  */
 public class EntryEventMessagePayload<K, V> {
 
-	private K key;
+	public final K key;
 
-	private V value;
+	public final V value;
 
-	private V oldValue;
+	public final V oldValue;
 
-	private int numberOfEntriesAffected;
-
-	public EntryEventMessagePayload(int numberOfEntriesAffected) {
-		this.numberOfEntriesAffected = numberOfEntriesAffected;
-	}
-
-	public EntryEventMessagePayload(K key, V value, V oldValue) {
+	public EntryEventMessagePayload(final K key, final V value, final V oldValue) {
 		Assert.notNull(key, "key must not be null");
 		this.key = key;
 		this.value = value;
 		this.oldValue = oldValue;
 	}
 
-	public K getKey() {
-		return key;
+	@Override
+	public String toString() {
+		return "EntryEventMessagePayload [key=" + key + ", value=" + value
+				+ ", oldValue=" + oldValue + "]";
 	}
 
-	public V getValue() {
-		return value;
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((key == null) ? 0 : key.hashCode());
+		result = prime * result + ((oldValue == null) ? 0 : oldValue.hashCode());
+		result = prime * result + ((value == null) ? 0 : value.hashCode());
+		return result;
 	}
 
-	public V getOldValue() {
-		return oldValue;
-	}
-
-	public int getNumberOfEntriesAffected() {
-		return numberOfEntriesAffected;
+	@SuppressWarnings("rawtypes")
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		EntryEventMessagePayload other = (EntryEventMessagePayload) obj;
+		if (key == null) {
+			if (other.key != null)
+				return false;
+		}
+		else if (!key.equals(other.key))
+			return false;
+		if (oldValue == null) {
+			if (other.oldValue != null)
+				return false;
+		}
+		else if (!oldValue.equals(other.oldValue))
+			return false;
+		if (value == null) {
+			if (other.value != null)
+				return false;
+		}
+		else if (!value.equals(other.value))
+			return false;
+		return true;
 	}
 
 }

--- a/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/message/EntryEventMessagePayload.java
+++ b/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/message/EntryEventMessagePayload.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.hazelcast.message;
+
+import org.springframework.util.Assert;
+
+/**
+ * Hazelcast Message Payload for Entry Events
+ *
+ * @author Eren Avsarogullari
+ * @since 1.0.0
+ */
+public class EntryEventMessagePayload<K, V> {
+
+	private K key;
+
+	private V value;
+
+	private V oldValue;
+
+	private int numberOfEntriesAffected;
+
+	public EntryEventMessagePayload(int numberOfEntriesAffected) {
+		this.numberOfEntriesAffected = numberOfEntriesAffected;
+	}
+
+	public EntryEventMessagePayload(K key, V value, V oldValue) {
+		Assert.notNull(key, "key must not be null");
+		this.key = key;
+		this.value = value;
+		this.oldValue = oldValue;
+	}
+
+	public K getKey() {
+		return key;
+	}
+
+	public V getValue() {
+		return value;
+	}
+
+	public V getOldValue() {
+		return oldValue;
+	}
+
+	public int getNumberOfEntriesAffected() {
+		return numberOfEntriesAffected;
+	}
+
+}

--- a/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/message/HazelcastHeaders.java
+++ b/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/message/HazelcastHeaders.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.hazelcast.message;
+
+/**
+ * Hazelcast Message Headers
+ *
+ * @author Eren Avsarogullari
+ * @since 1.0.0
+ */
+public abstract class HazelcastHeaders {
+
+	private static final String PREFIX = "hazelcast_";
+
+	public static final String EVENT = PREFIX + "event";
+
+	public static final String MEMBER = PREFIX + "member";
+
+	public static final String NAME = PREFIX + "name";
+
+	public static final String PUBLISHING_TIME = PREFIX + "publishingTime";
+}

--- a/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/message/package-info.java
+++ b/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/message/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Provides classes supporting Hazelcast message headers and payload.
+ */
+package org.springframework.integration.hazelcast.message;

--- a/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/outbound/HazelcastCacheWritingMessageHandler.java
+++ b/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/outbound/HazelcastCacheWritingMessageHandler.java
@@ -22,7 +22,7 @@ import java.util.Queue;
 import java.util.Set;
 
 import org.springframework.integration.handler.AbstractMessageHandler;
-import org.springframework.integration.hazelcast.common.HazelcastIntegrationDefinitionValidator;
+import org.springframework.integration.hazelcast.HazelcastIntegrationDefinitionValidator;
 import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
 

--- a/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/package-info.java
+++ b/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Provides common used types and classes.
+ */
+package org.springframework.integration.hazelcast;

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/AbstractHazelcastTestSupport.java
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/AbstractHazelcastTestSupport.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.hazelcast;
+
+import org.junit.Assert;
+
+import org.springframework.integration.hazelcast.message.EntryEventMessagePayload;
+import org.springframework.messaging.Message;
+
+import com.hazelcast.core.EntryEventType;
+
+/**
+ * Base Class for Hazelcast Test Support
+ *
+ * @author Eren Avsarogullari
+ * @since 1.0.0
+ */
+public class AbstractHazelcastTestSupport {
+
+	protected void verifyEntryEvent(Message<?> msg, String cacheName, EntryEventType event) {
+		Assert.assertNotNull(msg);
+		Assert.assertNotNull(msg.getPayload());
+		if (event == EntryEventType.CLEAR_ALL || event == EntryEventType.EVICT_ALL) {
+			Assert.assertTrue(msg.getPayload() instanceof Integer);
+		}
+		else {
+			Assert.assertTrue(msg.getPayload() instanceof EntryEventMessagePayload);
+		}
+
+		Assert.assertEquals(cacheName, msg.getHeaders().get(HazelcastHeaders.CACHE_NAME));
+		Assert.assertEquals(event.name(), msg.getHeaders().get(HazelcastHeaders.EVENT_TYPE));
+		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
+	}
+
+	protected void verifyItemEvent(Message<?> msg, EntryEventType event) {
+		Assert.assertNotNull(msg);
+		Assert.assertNotNull(msg.getPayload());
+		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
+		Assert.assertEquals(event.toString(), msg.getHeaders().get(HazelcastHeaders.EVENT_TYPE).toString());
+	}
+
+}

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastCQDistributedMapInboundChannelAdapterTests.java
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastCQDistributedMapInboundChannelAdapterTests.java
@@ -24,14 +24,14 @@ import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.hazelcast.HazelcastIntegrationTestUser;
+import org.springframework.integration.hazelcast.message.EntryEventMessagePayload;
+import org.springframework.integration.hazelcast.message.HazelcastHeaders;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import com.hazelcast.core.AbstractIMapEvent;
-import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.IMap;
 
@@ -44,6 +44,7 @@ import com.hazelcast.core.IMap;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
 @DirtiesContext
+@SuppressWarnings("unchecked")
 public class HazelcastCQDistributedMapInboundChannelAdapterTests {
 
 	@Autowired
@@ -84,18 +85,23 @@ public class HazelcastCQDistributedMapInboundChannelAdapterTests {
 		Message<?> msg = cqMapChannel1.receive(2_000);
 		Assert.assertNotNull(msg);
 		Assert.assertNotNull(msg.getPayload());
-		Assert.assertTrue(msg.getPayload() instanceof EntryEvent);
-		Assert.assertEquals(EntryEventType.ADDED,
-				((EntryEvent<?, ?>) msg.getPayload()).getEventType());
-		Assert.assertEquals("cqDistributedMap1",
-				((EntryEvent<?, ?>) msg.getPayload()).getName());
-		Assert.assertEquals(1, ((EntryEvent<?, ?>) msg.getPayload()).getKey());
+		Assert.assertTrue(msg.getPayload() instanceof EntryEventMessagePayload);
+		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
+		Assert.assertEquals(EntryEventType.ADDED, msg.getHeaders().get(HazelcastHeaders.EVENT));
+		Assert.assertEquals("cqDistributedMap1", msg.getHeaders().get(HazelcastHeaders.NAME));
+
+		Assert.assertEquals(Integer.valueOf(1),
+				((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getKey());
 		Assert.assertEquals(1,
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getValue()).getId());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getValue()).getId());
 		Assert.assertEquals("TestName1",
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getValue()).getName());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getValue()).getName());
 		Assert.assertEquals("TestSurname1",
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getValue()).getSurname());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getValue()).getSurname());
 	}
 
 	@Test
@@ -106,18 +112,23 @@ public class HazelcastCQDistributedMapInboundChannelAdapterTests {
 		Message<?> msg = cqMapChannel2.receive(2_000);
 		Assert.assertNotNull(msg);
 		Assert.assertNotNull(msg.getPayload());
-		Assert.assertTrue(msg.getPayload() instanceof EntryEvent);
-		Assert.assertEquals(EntryEventType.REMOVED,
-				((EntryEvent<?, ?>) msg.getPayload()).getEventType());
-		Assert.assertEquals("cqDistributedMap2",
-				((EntryEvent<?, ?>) msg.getPayload()).getName());
-		Assert.assertEquals(2, ((EntryEvent<?, ?>) msg.getPayload()).getKey());
+		Assert.assertTrue(msg.getPayload() instanceof EntryEventMessagePayload);
+		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
+		Assert.assertEquals(EntryEventType.REMOVED, msg.getHeaders().get(HazelcastHeaders.EVENT));
+		Assert.assertEquals("cqDistributedMap2", msg.getHeaders().get(HazelcastHeaders.NAME));
+
+		Assert.assertEquals(Integer.valueOf(2),
+				((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getKey());
 		Assert.assertEquals(2,
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getOldValue()).getId());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getOldValue()).getId());
 		Assert.assertEquals("TestName2",
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getOldValue()).getName());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getOldValue()).getName());
 		Assert.assertEquals("TestSurname2",
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getOldValue()).getSurname());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getOldValue()).getSurname());
 	}
 
 	@Test
@@ -150,24 +161,32 @@ public class HazelcastCQDistributedMapInboundChannelAdapterTests {
 		Message<?> msg = cqMapChannel4.receive(2_000);
 		Assert.assertNotNull(msg);
 		Assert.assertNotNull(msg.getPayload());
-		Assert.assertTrue(msg.getPayload() instanceof EntryEvent);
-		Assert.assertEquals(EntryEventType.UPDATED,
-				((EntryEvent<?, ?>) msg.getPayload()).getEventType());
-		Assert.assertEquals("cqDistributedMap4",
-				((EntryEvent<?, ?>) msg.getPayload()).getName());
-		Assert.assertEquals(1, ((EntryEvent<?, ?>) msg.getPayload()).getKey());
+		Assert.assertTrue(msg.getPayload() instanceof EntryEventMessagePayload);
+		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
+		Assert.assertEquals(EntryEventType.UPDATED, msg.getHeaders().get(HazelcastHeaders.EVENT));
+		Assert.assertEquals("cqDistributedMap4", msg.getHeaders().get(HazelcastHeaders.NAME));
+
+		Assert.assertEquals(Integer.valueOf(1),
+				((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getKey());
 		Assert.assertEquals(1,
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getOldValue()).getId());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getOldValue()).getId());
 		Assert.assertEquals("TestName1",
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getOldValue()).getName());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getOldValue()).getName());
 		Assert.assertEquals("TestSurname1",
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getOldValue()).getSurname());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getOldValue()).getSurname());
 		Assert.assertEquals(2,
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getValue()).getId());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getValue()).getId());
 		Assert.assertEquals("TestName2",
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getValue()).getName());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getValue()).getName());
 		Assert.assertEquals("TestSurname2",
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getValue()).getSurname());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getValue()).getSurname());
 	}
 
 	@Test
@@ -177,20 +196,22 @@ public class HazelcastCQDistributedMapInboundChannelAdapterTests {
 		Message<?> msg = cqMapChannel5.receive(2_000);
 		Assert.assertNotNull(msg);
 		Assert.assertNotNull(msg.getPayload());
-		Assert.assertTrue(msg.getPayload() instanceof EntryEvent);
-		Assert.assertEquals(EntryEventType.UPDATED, ((EntryEvent<?, ?>) msg.getPayload()).getEventType());
-		Assert.assertEquals("cqDistributedMap5", ((EntryEvent<?, ?>) msg.getPayload()).getName());
-		Assert.assertEquals(1, ((EntryEvent<?, ?>) msg.getPayload()).getKey());
-		Assert.assertNull(((EntryEvent<?, ?>) msg.getPayload()).getOldValue());
-		Assert.assertNull(((EntryEvent<?, ?>) msg.getPayload()).getValue());
+		Assert.assertTrue(msg.getPayload() instanceof EntryEventMessagePayload);
+		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
+		Assert.assertEquals(EntryEventType.UPDATED, msg.getHeaders().get(HazelcastHeaders.EVENT));
+		Assert.assertEquals("cqDistributedMap5", msg.getHeaders().get(HazelcastHeaders.NAME));
+
+		Assert.assertEquals(Integer.valueOf(1), ((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg.getPayload()).getKey());
+		Assert.assertNull(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg.getPayload()).getOldValue());
+		Assert.assertNull(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg.getPayload()).getValue());
 	}
 
-	private void verify(Message<?> msg, String cacheName, EntryEventType type) {
+	private void verify(Message<?> msg, String cacheName, EntryEventType event) {
 		Assert.assertNotNull(msg);
 		Assert.assertNotNull(msg.getPayload());
-		Assert.assertTrue(msg.getPayload() instanceof AbstractIMapEvent);
-		Assert.assertEquals(cacheName, ((AbstractIMapEvent) msg.getPayload()).getName());
-		Assert.assertEquals(type, ((AbstractIMapEvent) msg.getPayload()).getEventType());
+		Assert.assertTrue(msg.getPayload() instanceof EntryEventMessagePayload);
+		Assert.assertEquals(cacheName, msg.getHeaders().get(HazelcastHeaders.NAME));
+		Assert.assertEquals(event, msg.getHeaders().get(HazelcastHeaders.EVENT));
 	}
 
 }

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastCQDistributedMapInboundChannelAdapterTests.java
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastCQDistributedMapInboundChannelAdapterTests.java
@@ -23,9 +23,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.integration.hazelcast.AbstractHazelcastTestSupport;
+import org.springframework.integration.hazelcast.HazelcastHeaders;
 import org.springframework.integration.hazelcast.HazelcastIntegrationTestUser;
 import org.springframework.integration.hazelcast.message.EntryEventMessagePayload;
-import org.springframework.integration.hazelcast.message.HazelcastHeaders;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.test.annotation.DirtiesContext;
@@ -45,7 +46,7 @@ import com.hazelcast.core.IMap;
 @ContextConfiguration
 @DirtiesContext
 @SuppressWarnings("unchecked")
-public class HazelcastCQDistributedMapInboundChannelAdapterTests {
+public class HazelcastCQDistributedMapInboundChannelAdapterTests extends AbstractHazelcastTestSupport {
 
 	@Autowired
 	private PollableChannel cqMapChannel1;
@@ -87,21 +88,21 @@ public class HazelcastCQDistributedMapInboundChannelAdapterTests {
 		Assert.assertNotNull(msg.getPayload());
 		Assert.assertTrue(msg.getPayload() instanceof EntryEventMessagePayload);
 		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
-		Assert.assertEquals(EntryEventType.ADDED, msg.getHeaders().get(HazelcastHeaders.EVENT));
-		Assert.assertEquals("cqDistributedMap1", msg.getHeaders().get(HazelcastHeaders.NAME));
+		Assert.assertEquals(EntryEventType.ADDED.name(), msg.getHeaders().get(HazelcastHeaders.EVENT_TYPE));
+		Assert.assertEquals("cqDistributedMap1", msg.getHeaders().get(HazelcastHeaders.CACHE_NAME));
 
 		Assert.assertEquals(Integer.valueOf(1),
 				((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getKey());
+						.getPayload()).key);
 		Assert.assertEquals(1,
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getValue()).getId());
+						.getPayload()).value).getId());
 		Assert.assertEquals("TestName1",
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getValue()).getName());
+						.getPayload()).value).getName());
 		Assert.assertEquals("TestSurname1",
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getValue()).getSurname());
+						.getPayload()).value).getSurname());
 	}
 
 	@Test
@@ -114,44 +115,44 @@ public class HazelcastCQDistributedMapInboundChannelAdapterTests {
 		Assert.assertNotNull(msg.getPayload());
 		Assert.assertTrue(msg.getPayload() instanceof EntryEventMessagePayload);
 		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
-		Assert.assertEquals(EntryEventType.REMOVED, msg.getHeaders().get(HazelcastHeaders.EVENT));
-		Assert.assertEquals("cqDistributedMap2", msg.getHeaders().get(HazelcastHeaders.NAME));
+		Assert.assertEquals(EntryEventType.REMOVED.name(), msg.getHeaders().get(HazelcastHeaders.EVENT_TYPE));
+		Assert.assertEquals("cqDistributedMap2", msg.getHeaders().get(HazelcastHeaders.CACHE_NAME));
 
 		Assert.assertEquals(Integer.valueOf(2),
 				((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getKey());
+						.getPayload()).key);
 		Assert.assertEquals(2,
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getOldValue()).getId());
+						.getPayload()).oldValue).getId());
 		Assert.assertEquals("TestName2",
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getOldValue()).getName());
+						.getPayload()).oldValue).getName());
 		Assert.assertEquals("TestSurname2",
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getOldValue()).getSurname());
+						.getPayload()).oldValue).getSurname());
 	}
 
 	@Test
 	public void testContinuousQueryForALLEntryEvent() {
 		cqDistributedMap3.put(1, new HazelcastIntegrationTestUser(1, "TestName1", "TestSurname1"));
 		Message<?> msg = cqMapChannel3.receive(2_000);
-		verify(msg, "cqDistributedMap3", EntryEventType.ADDED);
+		verifyEntryEvent(msg, "cqDistributedMap3", EntryEventType.ADDED);
 
 		cqDistributedMap3.put(1, new HazelcastIntegrationTestUser(1, "TestName1", "TestSurnameUpdated"));
 		msg = cqMapChannel3.receive(2_000);
-		verify(msg, "cqDistributedMap3", EntryEventType.UPDATED);
+		verifyEntryEvent(msg, "cqDistributedMap3", EntryEventType.UPDATED);
 
 		cqDistributedMap3.remove(1);
 		msg = cqMapChannel3.receive(2_000);
-		verify(msg, "cqDistributedMap3", EntryEventType.REMOVED);
+		verifyEntryEvent(msg, "cqDistributedMap3", EntryEventType.REMOVED);
 
 		cqDistributedMap3.put(2, new HazelcastIntegrationTestUser(2, "TestName2", "TestSurname2"));
 		msg = cqMapChannel3.receive(2_000);
-		verify(msg, "cqDistributedMap3", EntryEventType.ADDED);
+		verifyEntryEvent(msg, "cqDistributedMap3", EntryEventType.ADDED);
 
 		cqDistributedMap3.clear();
 		msg = cqMapChannel3.receive(2_000);
-		verify(msg, "cqDistributedMap3", EntryEventType.CLEAR_ALL);
+		verifyEntryEvent(msg, "cqDistributedMap3", EntryEventType.CLEAR_ALL);
 	}
 
 	@Test
@@ -163,30 +164,30 @@ public class HazelcastCQDistributedMapInboundChannelAdapterTests {
 		Assert.assertNotNull(msg.getPayload());
 		Assert.assertTrue(msg.getPayload() instanceof EntryEventMessagePayload);
 		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
-		Assert.assertEquals(EntryEventType.UPDATED, msg.getHeaders().get(HazelcastHeaders.EVENT));
-		Assert.assertEquals("cqDistributedMap4", msg.getHeaders().get(HazelcastHeaders.NAME));
+		Assert.assertEquals(EntryEventType.UPDATED.name(), msg.getHeaders().get(HazelcastHeaders.EVENT_TYPE));
+		Assert.assertEquals("cqDistributedMap4", msg.getHeaders().get(HazelcastHeaders.CACHE_NAME));
 
 		Assert.assertEquals(Integer.valueOf(1),
 				((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getKey());
+						.getPayload()).key);
 		Assert.assertEquals(1,
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getOldValue()).getId());
+						.getPayload()).oldValue).getId());
 		Assert.assertEquals("TestName1",
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getOldValue()).getName());
+						.getPayload()).oldValue).getName());
 		Assert.assertEquals("TestSurname1",
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getOldValue()).getSurname());
+						.getPayload()).oldValue).getSurname());
 		Assert.assertEquals(2,
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getValue()).getId());
+						.getPayload()).value).getId());
 		Assert.assertEquals("TestName2",
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getValue()).getName());
+						.getPayload()).value).getName());
 		Assert.assertEquals("TestSurname2",
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getValue()).getSurname());
+						.getPayload()).value).getSurname());
 	}
 
 	@Test
@@ -198,20 +199,12 @@ public class HazelcastCQDistributedMapInboundChannelAdapterTests {
 		Assert.assertNotNull(msg.getPayload());
 		Assert.assertTrue(msg.getPayload() instanceof EntryEventMessagePayload);
 		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
-		Assert.assertEquals(EntryEventType.UPDATED, msg.getHeaders().get(HazelcastHeaders.EVENT));
-		Assert.assertEquals("cqDistributedMap5", msg.getHeaders().get(HazelcastHeaders.NAME));
+		Assert.assertEquals(EntryEventType.UPDATED.name(), msg.getHeaders().get(HazelcastHeaders.EVENT_TYPE));
+		Assert.assertEquals("cqDistributedMap5", msg.getHeaders().get(HazelcastHeaders.CACHE_NAME));
 
-		Assert.assertEquals(Integer.valueOf(1), ((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg.getPayload()).getKey());
-		Assert.assertNull(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg.getPayload()).getOldValue());
-		Assert.assertNull(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg.getPayload()).getValue());
-	}
-
-	private void verify(Message<?> msg, String cacheName, EntryEventType event) {
-		Assert.assertNotNull(msg);
-		Assert.assertNotNull(msg.getPayload());
-		Assert.assertTrue(msg.getPayload() instanceof EntryEventMessagePayload);
-		Assert.assertEquals(cacheName, msg.getHeaders().get(HazelcastHeaders.NAME));
-		Assert.assertEquals(event, msg.getHeaders().get(HazelcastHeaders.EVENT));
+		Assert.assertEquals(Integer.valueOf(1), ((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg.getPayload()).key);
+		Assert.assertNull(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg.getPayload()).oldValue);
+		Assert.assertNull(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg.getPayload()).value);
 	}
 
 }

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastDistributedListEventDrivenInboundChannelAdapterTests.java
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastDistributedListEventDrivenInboundChannelAdapterTests.java
@@ -24,6 +24,7 @@ import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.hazelcast.HazelcastIntegrationTestUser;
+import org.springframework.integration.hazelcast.message.HazelcastHeaders;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.test.annotation.DirtiesContext;
@@ -32,7 +33,6 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.IList;
-import com.hazelcast.core.ItemEvent;
 
 /**
  * Hazelcast Distributed List Event Driven Inbound Channel Adapter Test Class
@@ -69,15 +69,11 @@ public class HazelcastDistributedListEventDrivenInboundChannelAdapterTests {
 		Message<?> msg = edListChannel1.receive(2_000);
 		Assert.assertNotNull(msg);
 		Assert.assertNotNull(msg.getPayload());
-		Assert.assertTrue(msg.getPayload() instanceof ItemEvent);
-		Assert.assertEquals(EntryEventType.ADDED.toString(),
-				((ItemEvent<?>) msg.getPayload()).getEventType().toString());
-		Assert.assertEquals(1,
-				((HazelcastIntegrationTestUser) ((ItemEvent<?>) msg.getPayload()).getItem()).getId());
-		Assert.assertEquals("TestName1",
-				((HazelcastIntegrationTestUser) ((ItemEvent<?>) msg.getPayload()).getItem()).getName());
-		Assert.assertEquals("TestSurname1",
-				((HazelcastIntegrationTestUser) ((ItemEvent<?>) msg.getPayload()).getItem()).getSurname());
+		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
+		Assert.assertEquals(EntryEventType.ADDED.toString(), msg.getHeaders().get(HazelcastHeaders.EVENT).toString());
+		Assert.assertEquals(1, ((HazelcastIntegrationTestUser) msg.getPayload()).getId());
+		Assert.assertEquals("TestName1", ((HazelcastIntegrationTestUser) msg.getPayload()).getName());
+		Assert.assertEquals("TestSurname1", ((HazelcastIntegrationTestUser) msg.getPayload()).getSurname());
 	}
 
 	@Test
@@ -88,15 +84,11 @@ public class HazelcastDistributedListEventDrivenInboundChannelAdapterTests {
 		Message<?> msg = edListChannel2.receive(2_000);
 		Assert.assertNotNull(msg);
 		Assert.assertNotNull(msg.getPayload());
-		Assert.assertTrue(msg.getPayload() instanceof ItemEvent);
-		Assert.assertEquals(EntryEventType.REMOVED.toString(),
-				((ItemEvent<?>) msg.getPayload()).getEventType().toString());
-		Assert.assertEquals(2,
-				((HazelcastIntegrationTestUser) ((ItemEvent<?>) msg.getPayload()).getItem()).getId());
-		Assert.assertEquals("TestName2",
-				((HazelcastIntegrationTestUser) ((ItemEvent<?>) msg.getPayload()).getItem()).getName());
-		Assert.assertEquals("TestSurname2",
-				((HazelcastIntegrationTestUser) ((ItemEvent<?>) msg.getPayload()).getItem()).getSurname());
+		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
+		Assert.assertEquals(EntryEventType.REMOVED.toString(), msg.getHeaders().get(HazelcastHeaders.EVENT).toString());
+		Assert.assertEquals(2, ((HazelcastIntegrationTestUser) msg.getPayload()).getId());
+		Assert.assertEquals("TestName2", ((HazelcastIntegrationTestUser) msg.getPayload()).getName());
+		Assert.assertEquals("TestSurname2", ((HazelcastIntegrationTestUser) msg.getPayload()).getSurname());
 	}
 
 	@Test
@@ -116,12 +108,11 @@ public class HazelcastDistributedListEventDrivenInboundChannelAdapterTests {
 		verify(msg, EntryEventType.ADDED);
 	}
 
-	private void verify(Message<?> msg, EntryEventType type) {
+	private void verify(Message<?> msg, EntryEventType event) {
 		Assert.assertNotNull(msg);
 		Assert.assertNotNull(msg.getPayload());
-		Assert.assertTrue(msg.getPayload() instanceof ItemEvent);
-		Assert.assertEquals(type.toString(),
-				((ItemEvent<?>) msg.getPayload()).getEventType().toString());
+		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
+		Assert.assertEquals(event.toString(), msg.getHeaders().get(HazelcastHeaders.EVENT).toString());
 	}
 
 }

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastDistributedListEventDrivenInboundChannelAdapterTests.java
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastDistributedListEventDrivenInboundChannelAdapterTests.java
@@ -23,8 +23,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.integration.hazelcast.AbstractHazelcastTestSupport;
+import org.springframework.integration.hazelcast.HazelcastHeaders;
 import org.springframework.integration.hazelcast.HazelcastIntegrationTestUser;
-import org.springframework.integration.hazelcast.message.HazelcastHeaders;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.test.annotation.DirtiesContext;
@@ -43,7 +44,7 @@ import com.hazelcast.core.IList;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
 @DirtiesContext
-public class HazelcastDistributedListEventDrivenInboundChannelAdapterTests {
+public class HazelcastDistributedListEventDrivenInboundChannelAdapterTests extends AbstractHazelcastTestSupport {
 
 	@Autowired
 	private PollableChannel edListChannel1;
@@ -70,7 +71,7 @@ public class HazelcastDistributedListEventDrivenInboundChannelAdapterTests {
 		Assert.assertNotNull(msg);
 		Assert.assertNotNull(msg.getPayload());
 		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
-		Assert.assertEquals(EntryEventType.ADDED.toString(), msg.getHeaders().get(HazelcastHeaders.EVENT).toString());
+		Assert.assertEquals(EntryEventType.ADDED.toString(), msg.getHeaders().get(HazelcastHeaders.EVENT_TYPE).toString());
 		Assert.assertEquals(1, ((HazelcastIntegrationTestUser) msg.getPayload()).getId());
 		Assert.assertEquals("TestName1", ((HazelcastIntegrationTestUser) msg.getPayload()).getName());
 		Assert.assertEquals("TestSurname1", ((HazelcastIntegrationTestUser) msg.getPayload()).getSurname());
@@ -85,7 +86,7 @@ public class HazelcastDistributedListEventDrivenInboundChannelAdapterTests {
 		Assert.assertNotNull(msg);
 		Assert.assertNotNull(msg.getPayload());
 		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
-		Assert.assertEquals(EntryEventType.REMOVED.toString(), msg.getHeaders().get(HazelcastHeaders.EVENT).toString());
+		Assert.assertEquals(EntryEventType.REMOVED.toString(), msg.getHeaders().get(HazelcastHeaders.EVENT_TYPE).toString());
 		Assert.assertEquals(2, ((HazelcastIntegrationTestUser) msg.getPayload()).getId());
 		Assert.assertEquals("TestName2", ((HazelcastIntegrationTestUser) msg.getPayload()).getName());
 		Assert.assertEquals("TestSurname2", ((HazelcastIntegrationTestUser) msg.getPayload()).getSurname());
@@ -96,23 +97,16 @@ public class HazelcastDistributedListEventDrivenInboundChannelAdapterTests {
 		HazelcastIntegrationTestUser user = new HazelcastIntegrationTestUser(1, "TestName1", "TestSurname1");
 		edDistributedList3.add(user);
 		Message<?> msg = edListChannel3.receive(2_000);
-		verify(msg, EntryEventType.ADDED);
+		verifyItemEvent(msg, EntryEventType.ADDED);
 
 		edDistributedList3.remove(user);
 		msg = edListChannel3.receive(2_000);
-		verify(msg, EntryEventType.REMOVED);
+		verifyItemEvent(msg, EntryEventType.REMOVED);
 
 		user = new HazelcastIntegrationTestUser(2, "TestName2", "TestSurname2");
 		edDistributedList3.add(user);
 		msg = edListChannel3.receive(2_000);
-		verify(msg, EntryEventType.ADDED);
-	}
-
-	private void verify(Message<?> msg, EntryEventType event) {
-		Assert.assertNotNull(msg);
-		Assert.assertNotNull(msg.getPayload());
-		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
-		Assert.assertEquals(event.toString(), msg.getHeaders().get(HazelcastHeaders.EVENT).toString());
+		verifyItemEvent(msg, EntryEventType.ADDED);
 	}
 
 }

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastDistributedMapEventDrivenInboundChannelAdapterTests.java
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastDistributedMapEventDrivenInboundChannelAdapterTests.java
@@ -23,9 +23,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.integration.hazelcast.AbstractHazelcastTestSupport;
+import org.springframework.integration.hazelcast.HazelcastHeaders;
 import org.springframework.integration.hazelcast.HazelcastIntegrationTestUser;
 import org.springframework.integration.hazelcast.message.EntryEventMessagePayload;
-import org.springframework.integration.hazelcast.message.HazelcastHeaders;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.test.annotation.DirtiesContext;
@@ -45,7 +46,7 @@ import com.hazelcast.core.IMap;
 @ContextConfiguration
 @DirtiesContext
 @SuppressWarnings("unchecked")
-public class HazelcastDistributedMapEventDrivenInboundChannelAdapterTests {
+public class HazelcastDistributedMapEventDrivenInboundChannelAdapterTests extends AbstractHazelcastTestSupport {
 
 	@Autowired
 	private PollableChannel edMapChannel1;
@@ -79,20 +80,20 @@ public class HazelcastDistributedMapEventDrivenInboundChannelAdapterTests {
 		Assert.assertNotNull(msg.getPayload());
 		Assert.assertTrue(msg.getPayload() instanceof EntryEventMessagePayload);
 		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
-		Assert.assertEquals(EntryEventType.ADDED, msg.getHeaders().get(HazelcastHeaders.EVENT));
-		Assert.assertEquals("edDistributedMap1", msg.getHeaders().get(HazelcastHeaders.NAME));
+		Assert.assertEquals(EntryEventType.ADDED.name(), msg.getHeaders().get(HazelcastHeaders.EVENT_TYPE));
+		Assert.assertEquals("edDistributedMap1", msg.getHeaders().get(HazelcastHeaders.CACHE_NAME));
 
 		Assert.assertEquals(Integer.valueOf(1),
-				((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg.getPayload()).getKey());
+				((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg.getPayload()).key);
 		Assert.assertEquals(1,
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getValue()).getId());
+						.getPayload()).value).getId());
 		Assert.assertEquals("TestName1",
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getValue()).getName());
+						.getPayload()).value).getName());
 		Assert.assertEquals("TestSurname1",
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getValue()).getSurname());
+						.getPayload()).value).getSurname());
 	}
 
 	@Test
@@ -104,30 +105,30 @@ public class HazelcastDistributedMapEventDrivenInboundChannelAdapterTests {
 		Assert.assertNotNull(msg.getPayload());
 		Assert.assertTrue(msg.getPayload() instanceof EntryEventMessagePayload);
 		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
-		Assert.assertEquals(EntryEventType.UPDATED, msg.getHeaders().get(HazelcastHeaders.EVENT));
-		Assert.assertEquals("edDistributedMap2", msg.getHeaders().get(HazelcastHeaders.NAME));
+		Assert.assertEquals(EntryEventType.UPDATED.name(), msg.getHeaders().get(HazelcastHeaders.EVENT_TYPE));
+		Assert.assertEquals("edDistributedMap2", msg.getHeaders().get(HazelcastHeaders.CACHE_NAME));
 
 		Assert.assertEquals(Integer.valueOf(2),
 				((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getKey());
+						.getPayload()).key);
 		Assert.assertEquals(1,
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getOldValue()).getId());
+						.getPayload()).oldValue).getId());
 		Assert.assertEquals("TestName1",
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getOldValue()).getName());
+						.getPayload()).oldValue).getName());
 		Assert.assertEquals("TestSurname1",
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getOldValue()).getSurname());
+						.getPayload()).oldValue).getSurname());
 		Assert.assertEquals(2,
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getValue()).getId());
+						.getPayload()).value).getId());
 		Assert.assertEquals("TestName2",
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getValue()).getName());
+						.getPayload()).value).getName());
 		Assert.assertEquals("TestSurname2",
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getValue()).getSurname());
+						.getPayload()).value).getSurname());
 	}
 
 	@Test
@@ -140,52 +141,44 @@ public class HazelcastDistributedMapEventDrivenInboundChannelAdapterTests {
 		Assert.assertNotNull(msg.getPayload());
 		Assert.assertTrue(msg.getPayload() instanceof EntryEventMessagePayload);
 		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
-		Assert.assertEquals(EntryEventType.REMOVED, msg.getHeaders().get(HazelcastHeaders.EVENT));
-		Assert.assertEquals("edDistributedMap3", msg.getHeaders().get(HazelcastHeaders.NAME));
+		Assert.assertEquals(EntryEventType.REMOVED.name(), msg.getHeaders().get(HazelcastHeaders.EVENT_TYPE));
+		Assert.assertEquals("edDistributedMap3", msg.getHeaders().get(HazelcastHeaders.CACHE_NAME));
 
 		Assert.assertEquals(Integer.valueOf(2),
 				((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getKey());
+						.getPayload()).key);
 		Assert.assertEquals(2,
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getOldValue()).getId());
+						.getPayload()).oldValue).getId());
 		Assert.assertEquals("TestName2",
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getOldValue()).getName());
+						.getPayload()).oldValue).getName());
 		Assert.assertEquals("TestSurname2",
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getOldValue()).getSurname());
+						.getPayload()).oldValue).getSurname());
 	}
 
 	@Test
 	public void testEventDrivenForALLEntryEvent() {
 		edDistributedMap4.put(1, new HazelcastIntegrationTestUser(1, "TestName1", "TestSurname1"));
 		Message<?> msg = edMapChannel4.receive(2_000);
-		verify(msg, "edDistributedMap4", EntryEventType.ADDED);
+		verifyEntryEvent(msg, "edDistributedMap4", EntryEventType.ADDED);
 
 		edDistributedMap4.put(1, new HazelcastIntegrationTestUser(1, "TestName1", "TestSurnameUpdated"));
 		msg = edMapChannel4.receive(2_000);
-		verify(msg, "edDistributedMap4", EntryEventType.UPDATED);
+		verifyEntryEvent(msg, "edDistributedMap4", EntryEventType.UPDATED);
 
 		edDistributedMap4.remove(1);
 		msg = edMapChannel4.receive(2_000);
-		verify(msg, "edDistributedMap4", EntryEventType.REMOVED);
+		verifyEntryEvent(msg, "edDistributedMap4", EntryEventType.REMOVED);
 
 		edDistributedMap4.put(2, new HazelcastIntegrationTestUser(2, "TestName2", "TestSurname2"));
 		msg = edMapChannel4.receive(2_000);
-		verify(msg, "edDistributedMap4", EntryEventType.ADDED);
+		verifyEntryEvent(msg, "edDistributedMap4", EntryEventType.ADDED);
 
 		edDistributedMap4.clear();
 		msg = edMapChannel4.receive(2_000);
-		verify(msg, "edDistributedMap4", EntryEventType.CLEAR_ALL);
-	}
-
-	private void verify(Message<?> msg, String cacheName, EntryEventType event) {
-		Assert.assertNotNull(msg);
-		Assert.assertNotNull(msg.getPayload());
-		Assert.assertTrue(msg.getPayload() instanceof EntryEventMessagePayload);
-		Assert.assertEquals(cacheName, msg.getHeaders().get(HazelcastHeaders.NAME));
-		Assert.assertEquals(event, msg.getHeaders().get(HazelcastHeaders.EVENT));
+		verifyEntryEvent(msg, "edDistributedMap4", EntryEventType.CLEAR_ALL);
 	}
 
 }

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastDistributedMapEventDrivenInboundChannelAdapterTests.java
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastDistributedMapEventDrivenInboundChannelAdapterTests.java
@@ -24,14 +24,14 @@ import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.hazelcast.HazelcastIntegrationTestUser;
+import org.springframework.integration.hazelcast.message.EntryEventMessagePayload;
+import org.springframework.integration.hazelcast.message.HazelcastHeaders;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import com.hazelcast.core.AbstractIMapEvent;
-import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.IMap;
 
@@ -44,6 +44,7 @@ import com.hazelcast.core.IMap;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
 @DirtiesContext
+@SuppressWarnings("unchecked")
 public class HazelcastDistributedMapEventDrivenInboundChannelAdapterTests {
 
 	@Autowired
@@ -76,18 +77,22 @@ public class HazelcastDistributedMapEventDrivenInboundChannelAdapterTests {
 		Message<?> msg = edMapChannel1.receive(2_000);
 		Assert.assertNotNull(msg);
 		Assert.assertNotNull(msg.getPayload());
-		Assert.assertTrue(msg.getPayload() instanceof EntryEvent);
-		Assert.assertEquals(EntryEventType.ADDED,
-				((EntryEvent<?, ?>) msg.getPayload()).getEventType());
-		Assert.assertEquals("edDistributedMap1",
-				((EntryEvent<?, ?>) msg.getPayload()).getName());
-		Assert.assertEquals(1, ((EntryEvent<?, ?>) msg.getPayload()).getKey());
+		Assert.assertTrue(msg.getPayload() instanceof EntryEventMessagePayload);
+		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
+		Assert.assertEquals(EntryEventType.ADDED, msg.getHeaders().get(HazelcastHeaders.EVENT));
+		Assert.assertEquals("edDistributedMap1", msg.getHeaders().get(HazelcastHeaders.NAME));
+
+		Assert.assertEquals(Integer.valueOf(1),
+				((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg.getPayload()).getKey());
 		Assert.assertEquals(1,
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getValue()).getId());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getValue()).getId());
 		Assert.assertEquals("TestName1",
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getValue()).getName());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getValue()).getName());
 		Assert.assertEquals("TestSurname1",
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getValue()).getSurname());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getValue()).getSurname());
 	}
 
 	@Test
@@ -97,24 +102,32 @@ public class HazelcastDistributedMapEventDrivenInboundChannelAdapterTests {
 		Message<?> msg = edMapChannel2.receive(2_000);
 		Assert.assertNotNull(msg);
 		Assert.assertNotNull(msg.getPayload());
-		Assert.assertTrue(msg.getPayload() instanceof EntryEvent);
-		Assert.assertEquals(EntryEventType.UPDATED,
-				((EntryEvent<?, ?>) msg.getPayload()).getEventType());
-		Assert.assertEquals("edDistributedMap2",
-				((EntryEvent<?, ?>) msg.getPayload()).getName());
-		Assert.assertEquals(2, ((EntryEvent<?, ?>) msg.getPayload()).getKey());
+		Assert.assertTrue(msg.getPayload() instanceof EntryEventMessagePayload);
+		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
+		Assert.assertEquals(EntryEventType.UPDATED, msg.getHeaders().get(HazelcastHeaders.EVENT));
+		Assert.assertEquals("edDistributedMap2", msg.getHeaders().get(HazelcastHeaders.NAME));
+
+		Assert.assertEquals(Integer.valueOf(2),
+				((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getKey());
 		Assert.assertEquals(1,
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getOldValue()).getId());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getOldValue()).getId());
 		Assert.assertEquals("TestName1",
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getOldValue()).getName());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getOldValue()).getName());
 		Assert.assertEquals("TestSurname1",
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getOldValue()).getSurname());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getOldValue()).getSurname());
 		Assert.assertEquals(2,
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getValue()).getId());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getValue()).getId());
 		Assert.assertEquals("TestName2",
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getValue()).getName());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getValue()).getName());
 		Assert.assertEquals("TestSurname2",
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getValue()).getSurname());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getValue()).getSurname());
 	}
 
 	@Test
@@ -125,18 +138,23 @@ public class HazelcastDistributedMapEventDrivenInboundChannelAdapterTests {
 		Message<?> msg = edMapChannel3.receive(2_000);
 		Assert.assertNotNull(msg);
 		Assert.assertNotNull(msg.getPayload());
-		Assert.assertTrue(msg.getPayload() instanceof EntryEvent);
-		Assert.assertEquals(EntryEventType.REMOVED,
-				((EntryEvent<?, ?>) msg.getPayload()).getEventType());
-		Assert.assertEquals("edDistributedMap3",
-				((EntryEvent<?, ?>) msg.getPayload()).getName());
-		Assert.assertEquals(2, ((EntryEvent<?, ?>) msg.getPayload()).getKey());
+		Assert.assertTrue(msg.getPayload() instanceof EntryEventMessagePayload);
+		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
+		Assert.assertEquals(EntryEventType.REMOVED, msg.getHeaders().get(HazelcastHeaders.EVENT));
+		Assert.assertEquals("edDistributedMap3", msg.getHeaders().get(HazelcastHeaders.NAME));
+
+		Assert.assertEquals(Integer.valueOf(2),
+				((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getKey());
 		Assert.assertEquals(2,
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getOldValue()).getId());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getOldValue()).getId());
 		Assert.assertEquals("TestName2",
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getOldValue()).getName());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getOldValue()).getName());
 		Assert.assertEquals("TestSurname2",
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getOldValue()).getSurname());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getOldValue()).getSurname());
 	}
 
 	@Test
@@ -162,12 +180,12 @@ public class HazelcastDistributedMapEventDrivenInboundChannelAdapterTests {
 		verify(msg, "edDistributedMap4", EntryEventType.CLEAR_ALL);
 	}
 
-	private void verify(Message<?> msg, String cacheName, EntryEventType type) {
+	private void verify(Message<?> msg, String cacheName, EntryEventType event) {
 		Assert.assertNotNull(msg);
 		Assert.assertNotNull(msg.getPayload());
-		Assert.assertTrue(msg.getPayload() instanceof AbstractIMapEvent);
-		Assert.assertEquals(cacheName, ((AbstractIMapEvent) msg.getPayload()).getName());
-		Assert.assertEquals(type, ((AbstractIMapEvent) msg.getPayload()).getEventType());
+		Assert.assertTrue(msg.getPayload() instanceof EntryEventMessagePayload);
+		Assert.assertEquals(cacheName, msg.getHeaders().get(HazelcastHeaders.NAME));
+		Assert.assertEquals(event, msg.getHeaders().get(HazelcastHeaders.EVENT));
 	}
 
 }

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastDistributedQueueEventDrivenInboundChannelAdapterTests.java
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastDistributedQueueEventDrivenInboundChannelAdapterTests.java
@@ -24,6 +24,7 @@ import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.hazelcast.HazelcastIntegrationTestUser;
+import org.springframework.integration.hazelcast.message.HazelcastHeaders;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.test.annotation.DirtiesContext;
@@ -32,7 +33,6 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.IQueue;
-import com.hazelcast.core.ItemEvent;
 
 /**
  * Hazelcast Distributed Queue Event Driven Inbound Channel Adapter Test
@@ -69,15 +69,11 @@ public class HazelcastDistributedQueueEventDrivenInboundChannelAdapterTests {
 		Message<?> msg = edQueueChannel1.receive(2_000);
 		Assert.assertNotNull(msg);
 		Assert.assertNotNull(msg.getPayload());
-		Assert.assertTrue(msg.getPayload() instanceof ItemEvent);
-		Assert.assertEquals(EntryEventType.ADDED.toString(),
-				((ItemEvent<?>) msg.getPayload()).getEventType().toString());
-		Assert.assertEquals(1,
-				((HazelcastIntegrationTestUser) ((ItemEvent<?>) msg.getPayload()).getItem()).getId());
-		Assert.assertEquals("TestName1",
-				((HazelcastIntegrationTestUser) ((ItemEvent<?>) msg.getPayload()).getItem()).getName());
-		Assert.assertEquals("TestSurname1",
-				((HazelcastIntegrationTestUser) ((ItemEvent<?>) msg.getPayload()).getItem()).getSurname());
+		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
+		Assert.assertEquals(EntryEventType.ADDED.toString(), msg.getHeaders().get(HazelcastHeaders.EVENT).toString());
+		Assert.assertEquals(1, (((HazelcastIntegrationTestUser) msg.getPayload()).getId()));
+		Assert.assertEquals("TestName1", (((HazelcastIntegrationTestUser) msg.getPayload()).getName()));
+		Assert.assertEquals("TestSurname1", (((HazelcastIntegrationTestUser) msg.getPayload()).getSurname()));
 	}
 
 	@Test
@@ -88,15 +84,11 @@ public class HazelcastDistributedQueueEventDrivenInboundChannelAdapterTests {
 		Message<?> msg = edQueueChannel2.receive(2_000);
 		Assert.assertNotNull(msg);
 		Assert.assertNotNull(msg.getPayload());
-		Assert.assertTrue(msg.getPayload() instanceof ItemEvent);
-		Assert.assertEquals(EntryEventType.REMOVED.toString(),
-				((ItemEvent<?>) msg.getPayload()).getEventType().toString());
-		Assert.assertEquals(2,
-				((HazelcastIntegrationTestUser) ((ItemEvent<?>) msg.getPayload()).getItem()).getId());
-		Assert.assertEquals("TestName2",
-				((HazelcastIntegrationTestUser) ((ItemEvent<?>) msg.getPayload()).getItem()).getName());
-		Assert.assertEquals("TestSurname2",
-				((HazelcastIntegrationTestUser) ((ItemEvent<?>) msg.getPayload()).getItem()).getSurname());
+		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
+		Assert.assertEquals(EntryEventType.REMOVED.toString(), msg.getHeaders().get(HazelcastHeaders.EVENT).toString());
+		Assert.assertEquals(2, (((HazelcastIntegrationTestUser) msg.getPayload()).getId()));
+		Assert.assertEquals("TestName2", (((HazelcastIntegrationTestUser) msg.getPayload()).getName()));
+		Assert.assertEquals("TestSurname2", (((HazelcastIntegrationTestUser) msg.getPayload()).getSurname()));
 	}
 
 	@Test
@@ -116,12 +108,11 @@ public class HazelcastDistributedQueueEventDrivenInboundChannelAdapterTests {
 		verify(msg, EntryEventType.ADDED);
 	}
 
-	private void verify(Message<?> msg, EntryEventType type) {
+	private void verify(Message<?> msg, EntryEventType event) {
 		Assert.assertNotNull(msg);
 		Assert.assertNotNull(msg.getPayload());
-		Assert.assertTrue(msg.getPayload() instanceof ItemEvent);
-		Assert.assertEquals(type.toString(), ((ItemEvent<?>) msg.getPayload())
-				.getEventType().toString());
+		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
+		Assert.assertEquals(event.toString(), msg.getHeaders().get(HazelcastHeaders.EVENT).toString());
 	}
 
 }

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastDistributedQueueEventDrivenInboundChannelAdapterTests.java
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastDistributedQueueEventDrivenInboundChannelAdapterTests.java
@@ -23,8 +23,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.integration.hazelcast.AbstractHazelcastTestSupport;
+import org.springframework.integration.hazelcast.HazelcastHeaders;
 import org.springframework.integration.hazelcast.HazelcastIntegrationTestUser;
-import org.springframework.integration.hazelcast.message.HazelcastHeaders;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.test.annotation.DirtiesContext;
@@ -43,7 +44,7 @@ import com.hazelcast.core.IQueue;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
 @DirtiesContext
-public class HazelcastDistributedQueueEventDrivenInboundChannelAdapterTests {
+public class HazelcastDistributedQueueEventDrivenInboundChannelAdapterTests extends AbstractHazelcastTestSupport {
 
 	@Autowired
 	private PollableChannel edQueueChannel1;
@@ -70,7 +71,7 @@ public class HazelcastDistributedQueueEventDrivenInboundChannelAdapterTests {
 		Assert.assertNotNull(msg);
 		Assert.assertNotNull(msg.getPayload());
 		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
-		Assert.assertEquals(EntryEventType.ADDED.toString(), msg.getHeaders().get(HazelcastHeaders.EVENT).toString());
+		Assert.assertEquals(EntryEventType.ADDED.toString(), msg.getHeaders().get(HazelcastHeaders.EVENT_TYPE).toString());
 		Assert.assertEquals(1, (((HazelcastIntegrationTestUser) msg.getPayload()).getId()));
 		Assert.assertEquals("TestName1", (((HazelcastIntegrationTestUser) msg.getPayload()).getName()));
 		Assert.assertEquals("TestSurname1", (((HazelcastIntegrationTestUser) msg.getPayload()).getSurname()));
@@ -85,7 +86,7 @@ public class HazelcastDistributedQueueEventDrivenInboundChannelAdapterTests {
 		Assert.assertNotNull(msg);
 		Assert.assertNotNull(msg.getPayload());
 		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
-		Assert.assertEquals(EntryEventType.REMOVED.toString(), msg.getHeaders().get(HazelcastHeaders.EVENT).toString());
+		Assert.assertEquals(EntryEventType.REMOVED.toString(), msg.getHeaders().get(HazelcastHeaders.EVENT_TYPE).toString());
 		Assert.assertEquals(2, (((HazelcastIntegrationTestUser) msg.getPayload()).getId()));
 		Assert.assertEquals("TestName2", (((HazelcastIntegrationTestUser) msg.getPayload()).getName()));
 		Assert.assertEquals("TestSurname2", (((HazelcastIntegrationTestUser) msg.getPayload()).getSurname()));
@@ -96,23 +97,16 @@ public class HazelcastDistributedQueueEventDrivenInboundChannelAdapterTests {
 		HazelcastIntegrationTestUser user = new HazelcastIntegrationTestUser(1, "TestName1", "TestSurname1");
 		edDistributedQueue3.add(user);
 		Message<?> msg = edQueueChannel3.receive(2_000);
-		verify(msg, EntryEventType.ADDED);
+		verifyItemEvent(msg, EntryEventType.ADDED);
 
 		edDistributedQueue3.remove(user);
 		msg = edQueueChannel3.receive(2_000);
-		verify(msg, EntryEventType.REMOVED);
+		verifyItemEvent(msg, EntryEventType.REMOVED);
 
 		user = new HazelcastIntegrationTestUser(2, "TestName2", "TestSurname2");
 		edDistributedQueue3.add(user);
 		msg = edQueueChannel3.receive(2_000);
-		verify(msg, EntryEventType.ADDED);
-	}
-
-	private void verify(Message<?> msg, EntryEventType event) {
-		Assert.assertNotNull(msg);
-		Assert.assertNotNull(msg.getPayload());
-		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
-		Assert.assertEquals(event.toString(), msg.getHeaders().get(HazelcastHeaders.EVENT).toString());
+		verifyItemEvent(msg, EntryEventType.ADDED);
 	}
 
 }

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastDistributedSetEventDrivenInboundChannelAdapterTests.java
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastDistributedSetEventDrivenInboundChannelAdapterTests.java
@@ -23,8 +23,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.integration.hazelcast.AbstractHazelcastTestSupport;
+import org.springframework.integration.hazelcast.HazelcastHeaders;
 import org.springframework.integration.hazelcast.HazelcastIntegrationTestUser;
-import org.springframework.integration.hazelcast.message.HazelcastHeaders;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.test.annotation.DirtiesContext;
@@ -43,7 +44,7 @@ import com.hazelcast.core.ISet;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
 @DirtiesContext
-public class HazelcastDistributedSetEventDrivenInboundChannelAdapterTests {
+public class HazelcastDistributedSetEventDrivenInboundChannelAdapterTests extends AbstractHazelcastTestSupport {
 
 	@Autowired
 	private PollableChannel edSetChannel1;
@@ -70,7 +71,7 @@ public class HazelcastDistributedSetEventDrivenInboundChannelAdapterTests {
 		Assert.assertNotNull(msg);
 		Assert.assertNotNull(msg.getPayload());
 		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
-		Assert.assertEquals(EntryEventType.ADDED.toString(), msg.getHeaders().get(HazelcastHeaders.EVENT).toString());
+		Assert.assertEquals(EntryEventType.ADDED.toString(), msg.getHeaders().get(HazelcastHeaders.EVENT_TYPE).toString());
 		Assert.assertEquals(1, (((HazelcastIntegrationTestUser) msg.getPayload()).getId()));
 		Assert.assertEquals("TestName1", (((HazelcastIntegrationTestUser) msg.getPayload()).getName()));
 		Assert.assertEquals("TestSurname1", (((HazelcastIntegrationTestUser) msg.getPayload()).getSurname()));
@@ -85,7 +86,7 @@ public class HazelcastDistributedSetEventDrivenInboundChannelAdapterTests {
 		Assert.assertNotNull(msg);
 		Assert.assertNotNull(msg.getPayload());
 		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
-		Assert.assertEquals(EntryEventType.REMOVED.toString(), msg.getHeaders().get(HazelcastHeaders.EVENT).toString());
+		Assert.assertEquals(EntryEventType.REMOVED.toString(), msg.getHeaders().get(HazelcastHeaders.EVENT_TYPE).toString());
 		Assert.assertEquals(2, (((HazelcastIntegrationTestUser) msg.getPayload()).getId()));
 		Assert.assertEquals("TestName2", (((HazelcastIntegrationTestUser) msg.getPayload()).getName()));
 		Assert.assertEquals("TestSurname2", (((HazelcastIntegrationTestUser) msg.getPayload()).getSurname()));
@@ -96,23 +97,16 @@ public class HazelcastDistributedSetEventDrivenInboundChannelAdapterTests {
 		HazelcastIntegrationTestUser user = new HazelcastIntegrationTestUser(1, "TestName1", "TestSurname1");
 		edDistributedSet3.add(user);
 		Message<?> msg = edSetChannel3.receive(2_000);
-		verify(msg, EntryEventType.ADDED);
+		verifyItemEvent(msg, EntryEventType.ADDED);
 
 		edDistributedSet3.remove(user);
 		msg = edSetChannel3.receive(2_000);
-		verify(msg, EntryEventType.REMOVED);
+		verifyItemEvent(msg, EntryEventType.REMOVED);
 
 		user = new HazelcastIntegrationTestUser(2, "TestName2", "TestSurname2");
 		edDistributedSet3.add(user);
 		msg = edSetChannel3.receive(2_000);
-		verify(msg, EntryEventType.ADDED);
-	}
-
-	private void verify(Message<?> msg, EntryEventType event) {
-		Assert.assertNotNull(msg);
-		Assert.assertNotNull(msg.getPayload());
-		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
-		Assert.assertEquals(event.toString(), msg.getHeaders().get(HazelcastHeaders.EVENT).toString());
+		verifyItemEvent(msg, EntryEventType.ADDED);
 	}
 
 }

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastDistributedSetEventDrivenInboundChannelAdapterTests.java
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastDistributedSetEventDrivenInboundChannelAdapterTests.java
@@ -24,6 +24,7 @@ import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.hazelcast.HazelcastIntegrationTestUser;
+import org.springframework.integration.hazelcast.message.HazelcastHeaders;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.test.annotation.DirtiesContext;
@@ -32,7 +33,6 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.ISet;
-import com.hazelcast.core.ItemEvent;
 
 /**
  * Hazelcast Distributed Set Event Driven Inbound Channel Adapter Test
@@ -69,15 +69,11 @@ public class HazelcastDistributedSetEventDrivenInboundChannelAdapterTests {
 		Message<?> msg = edSetChannel1.receive(2_000);
 		Assert.assertNotNull(msg);
 		Assert.assertNotNull(msg.getPayload());
-		Assert.assertTrue(msg.getPayload() instanceof ItemEvent);
-		Assert.assertEquals(EntryEventType.ADDED.toString(),
-				((ItemEvent<?>) msg.getPayload()).getEventType().toString());
-		Assert.assertEquals(1,
-				((HazelcastIntegrationTestUser) ((ItemEvent<?>) msg.getPayload()).getItem()).getId());
-		Assert.assertEquals("TestName1",
-				((HazelcastIntegrationTestUser) ((ItemEvent<?>) msg.getPayload()).getItem()).getName());
-		Assert.assertEquals("TestSurname1",
-				((HazelcastIntegrationTestUser) ((ItemEvent<?>) msg.getPayload()).getItem()).getSurname());
+		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
+		Assert.assertEquals(EntryEventType.ADDED.toString(), msg.getHeaders().get(HazelcastHeaders.EVENT).toString());
+		Assert.assertEquals(1, (((HazelcastIntegrationTestUser) msg.getPayload()).getId()));
+		Assert.assertEquals("TestName1", (((HazelcastIntegrationTestUser) msg.getPayload()).getName()));
+		Assert.assertEquals("TestSurname1", (((HazelcastIntegrationTestUser) msg.getPayload()).getSurname()));
 	}
 
 	@Test
@@ -88,15 +84,11 @@ public class HazelcastDistributedSetEventDrivenInboundChannelAdapterTests {
 		Message<?> msg = edSetChannel2.receive(2_000);
 		Assert.assertNotNull(msg);
 		Assert.assertNotNull(msg.getPayload());
-		Assert.assertTrue(msg.getPayload() instanceof ItemEvent);
-		Assert.assertEquals(EntryEventType.REMOVED.toString(),
-				((ItemEvent<?>) msg.getPayload()).getEventType().toString());
-		Assert.assertEquals(2,
-				((HazelcastIntegrationTestUser) ((ItemEvent<?>) msg.getPayload()).getItem()).getId());
-		Assert.assertEquals("TestName2",
-				((HazelcastIntegrationTestUser) ((ItemEvent<?>) msg.getPayload()).getItem()).getName());
-		Assert.assertEquals("TestSurname2",
-				((HazelcastIntegrationTestUser) ((ItemEvent<?>) msg.getPayload()).getItem()).getSurname());
+		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
+		Assert.assertEquals(EntryEventType.REMOVED.toString(), msg.getHeaders().get(HazelcastHeaders.EVENT).toString());
+		Assert.assertEquals(2, (((HazelcastIntegrationTestUser) msg.getPayload()).getId()));
+		Assert.assertEquals("TestName2", (((HazelcastIntegrationTestUser) msg.getPayload()).getName()));
+		Assert.assertEquals("TestSurname2", (((HazelcastIntegrationTestUser) msg.getPayload()).getSurname()));
 	}
 
 	@Test
@@ -116,12 +108,11 @@ public class HazelcastDistributedSetEventDrivenInboundChannelAdapterTests {
 		verify(msg, EntryEventType.ADDED);
 	}
 
-	private void verify(Message<?> msg, EntryEventType type) {
+	private void verify(Message<?> msg, EntryEventType event) {
 		Assert.assertNotNull(msg);
 		Assert.assertNotNull(msg.getPayload());
-		Assert.assertTrue(msg.getPayload() instanceof ItemEvent);
-		Assert.assertEquals(type.toString(),
-				((ItemEvent<?>) msg.getPayload()).getEventType().toString());
+		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
+		Assert.assertEquals(event.toString(), msg.getHeaders().get(HazelcastHeaders.EVENT).toString());
 	}
 
 }

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastDistributedTopicEventDrivenInboundChannelAdapterTests.java
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastDistributedTopicEventDrivenInboundChannelAdapterTests.java
@@ -23,8 +23,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.integration.hazelcast.HazelcastHeaders;
 import org.springframework.integration.hazelcast.HazelcastIntegrationTestUser;
-import org.springframework.integration.hazelcast.message.HazelcastHeaders;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.test.annotation.DirtiesContext;
@@ -58,7 +58,7 @@ public class HazelcastDistributedTopicEventDrivenInboundChannelAdapterTests {
 		Assert.assertNotNull(msg.getPayload());
 		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
 		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.PUBLISHING_TIME));
-		Assert.assertEquals("edDistributedTopic1", msg.getHeaders().get(HazelcastHeaders.NAME));
+		Assert.assertEquals("edDistributedTopic1", msg.getHeaders().get(HazelcastHeaders.CACHE_NAME));
 		Assert.assertEquals(1, ((HazelcastIntegrationTestUser) msg.getPayload()).getId());
 		Assert.assertEquals("TestName1", ((HazelcastIntegrationTestUser) msg.getPayload()).getName());
 		Assert.assertEquals("TestSurname1", ((HazelcastIntegrationTestUser) msg.getPayload()).getSurname());

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastDistributedTopicEventDrivenInboundChannelAdapterTests.java
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastDistributedTopicEventDrivenInboundChannelAdapterTests.java
@@ -24,6 +24,7 @@ import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.hazelcast.HazelcastIntegrationTestUser;
+import org.springframework.integration.hazelcast.message.HazelcastHeaders;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.test.annotation.DirtiesContext;
@@ -55,13 +56,12 @@ public class HazelcastDistributedTopicEventDrivenInboundChannelAdapterTests {
 		Message<?> msg = edTopicChannel1.receive(2_000);
 		Assert.assertNotNull(msg);
 		Assert.assertNotNull(msg.getPayload());
-		Assert.assertTrue(msg.getPayload() instanceof com.hazelcast.core.Message);
-		Assert.assertEquals(1, ((HazelcastIntegrationTestUser) ((com.hazelcast.core.Message<?>) msg.getPayload())
-				.getMessageObject()).getId());
-		Assert.assertEquals("TestName1", ((HazelcastIntegrationTestUser) ((com.hazelcast.core.Message<?>) msg
-				.getPayload()).getMessageObject()).getName());
-		Assert.assertEquals("TestSurname1", ((HazelcastIntegrationTestUser) ((com.hazelcast.core.Message<?>) msg
-				.getPayload()).getMessageObject()).getSurname());
+		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
+		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.PUBLISHING_TIME));
+		Assert.assertEquals("edDistributedTopic1", msg.getHeaders().get(HazelcastHeaders.NAME));
+		Assert.assertEquals(1, ((HazelcastIntegrationTestUser) msg.getPayload()).getId());
+		Assert.assertEquals("TestName1", ((HazelcastIntegrationTestUser) msg.getPayload()).getName());
+		Assert.assertEquals("TestSurname1", ((HazelcastIntegrationTestUser) msg.getPayload()).getSurname());
 	}
 
 }

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastMultiMapEventDrivenInboundChannelAdapterTests.java
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastMultiMapEventDrivenInboundChannelAdapterTests.java
@@ -23,9 +23,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.integration.hazelcast.AbstractHazelcastTestSupport;
+import org.springframework.integration.hazelcast.HazelcastHeaders;
 import org.springframework.integration.hazelcast.HazelcastIntegrationTestUser;
 import org.springframework.integration.hazelcast.message.EntryEventMessagePayload;
-import org.springframework.integration.hazelcast.message.HazelcastHeaders;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.test.annotation.DirtiesContext;
@@ -45,7 +46,7 @@ import com.hazelcast.core.MultiMap;
 @ContextConfiguration
 @DirtiesContext
 @SuppressWarnings("unchecked")
-public class HazelcastMultiMapEventDrivenInboundChannelAdapterTests {
+public class HazelcastMultiMapEventDrivenInboundChannelAdapterTests extends AbstractHazelcastTestSupport {
 
 	@Autowired
 	private PollableChannel edMultiMapChannel1;
@@ -73,21 +74,21 @@ public class HazelcastMultiMapEventDrivenInboundChannelAdapterTests {
 		Assert.assertNotNull(msg.getPayload());
 		Assert.assertTrue(msg.getPayload() instanceof EntryEventMessagePayload);
 		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
-		Assert.assertEquals(EntryEventType.ADDED, msg.getHeaders().get(HazelcastHeaders.EVENT));
-		Assert.assertEquals("edMultiMap1", msg.getHeaders().get(HazelcastHeaders.NAME));
+		Assert.assertEquals(EntryEventType.ADDED.name(), msg.getHeaders().get(HazelcastHeaders.EVENT_TYPE));
+		Assert.assertEquals("edMultiMap1", msg.getHeaders().get(HazelcastHeaders.CACHE_NAME));
 
 		Assert.assertEquals(Integer.valueOf(1),
 				((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getKey());
+						.getPayload()).key);
 		Assert.assertEquals(1,
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getValue()).getId());
+						.getPayload()).value).getId());
 		Assert.assertEquals("TestName1",
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getValue()).getName());
+						.getPayload()).value).getName());
 		Assert.assertEquals("TestSurname1",
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getValue()).getSurname());
+						.getPayload()).value).getSurname());
 	}
 
 	@Test
@@ -100,54 +101,46 @@ public class HazelcastMultiMapEventDrivenInboundChannelAdapterTests {
 		Assert.assertNotNull(msg.getPayload());
 		Assert.assertTrue(msg.getPayload() instanceof EntryEventMessagePayload);
 		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
-		Assert.assertEquals(EntryEventType.REMOVED, msg.getHeaders().get(HazelcastHeaders.EVENT));
-		Assert.assertEquals("edMultiMap2", msg.getHeaders().get(HazelcastHeaders.NAME));
+		Assert.assertEquals(EntryEventType.REMOVED.name(), msg.getHeaders().get(HazelcastHeaders.EVENT_TYPE));
+		Assert.assertEquals("edMultiMap2", msg.getHeaders().get(HazelcastHeaders.CACHE_NAME));
 
 		Assert.assertEquals(Integer.valueOf(2),
 				((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getKey());
+						.getPayload()).key);
 		Assert.assertEquals(2,
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getValue()).getId());
+						.getPayload()).value).getId());
 		Assert.assertEquals("TestName2",
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getValue()).getName());
+						.getPayload()).value).getName());
 		Assert.assertEquals("TestSurname2",
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getValue()).getSurname());
+						.getPayload()).value).getSurname());
 	}
 
 	@Test
 	public void testEventDrivenForALLEntryEvent() {
 		edMultiMap3.put(1, new HazelcastIntegrationTestUser(1, "TestName1", "TestSurname1"));
 		Message<?> msg = edMultiMapChannel3.receive(2_000);
-		verify(msg, "edMultiMap3", EntryEventType.ADDED);
+		verifyEntryEvent(msg, "edMultiMap3", EntryEventType.ADDED);
 
 		edMultiMap3.put(1, new HazelcastIntegrationTestUser(1, "TestName1", "TestSurnameUpdated"));
 		msg = edMultiMapChannel3.receive(2_000);
-		verify(msg, "edMultiMap3", EntryEventType.ADDED);
+		verifyEntryEvent(msg, "edMultiMap3", EntryEventType.ADDED);
 
 		edMultiMap3.remove(1);
 		msg = edMultiMapChannel3.receive(2_000);
-		verify(msg, "edMultiMap3", EntryEventType.REMOVED);
+		verifyEntryEvent(msg, "edMultiMap3", EntryEventType.REMOVED);
 		msg = edMultiMapChannel3.receive(2_000);
-		verify(msg, "edMultiMap3", EntryEventType.REMOVED);
+		verifyEntryEvent(msg, "edMultiMap3", EntryEventType.REMOVED);
 
 		edMultiMap3.put(2, new HazelcastIntegrationTestUser(2, "TestName2", "TestSurname2"));
 		msg = edMultiMapChannel3.receive(2_000);
-		verify(msg, "edMultiMap3", EntryEventType.ADDED);
+		verifyEntryEvent(msg, "edMultiMap3", EntryEventType.ADDED);
 
 		edMultiMap3.clear();
 		msg = edMultiMapChannel3.receive(2_000);
-		verify(msg, "edMultiMap3", EntryEventType.CLEAR_ALL);
-	}
-
-	private void verify(Message<?> msg, String cacheName, EntryEventType event) {
-		Assert.assertNotNull(msg);
-		Assert.assertNotNull(msg.getPayload());
-		Assert.assertTrue(msg.getPayload() instanceof EntryEventMessagePayload);
-		Assert.assertEquals(cacheName, msg.getHeaders().get(HazelcastHeaders.NAME));
-		Assert.assertEquals(event, msg.getHeaders().get(HazelcastHeaders.EVENT));
+		verifyEntryEvent(msg, "edMultiMap3", EntryEventType.CLEAR_ALL);
 	}
 
 }

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastMultiMapEventDrivenInboundChannelAdapterTests.java
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastMultiMapEventDrivenInboundChannelAdapterTests.java
@@ -24,14 +24,14 @@ import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.hazelcast.HazelcastIntegrationTestUser;
+import org.springframework.integration.hazelcast.message.EntryEventMessagePayload;
+import org.springframework.integration.hazelcast.message.HazelcastHeaders;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import com.hazelcast.core.AbstractIMapEvent;
-import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.MultiMap;
 
@@ -44,6 +44,7 @@ import com.hazelcast.core.MultiMap;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
 @DirtiesContext
+@SuppressWarnings("unchecked")
 public class HazelcastMultiMapEventDrivenInboundChannelAdapterTests {
 
 	@Autowired
@@ -70,18 +71,23 @@ public class HazelcastMultiMapEventDrivenInboundChannelAdapterTests {
 		Message<?> msg = edMultiMapChannel1.receive(2_000);
 		Assert.assertNotNull(msg);
 		Assert.assertNotNull(msg.getPayload());
-		Assert.assertTrue(msg.getPayload() instanceof EntryEvent);
-		Assert.assertEquals(EntryEventType.ADDED,
-				((EntryEvent<?, ?>) msg.getPayload()).getEventType());
-		Assert.assertEquals("edMultiMap1",
-				((EntryEvent<?, ?>) msg.getPayload()).getName());
-		Assert.assertEquals(1, ((EntryEvent<?, ?>) msg.getPayload()).getKey());
+		Assert.assertTrue(msg.getPayload() instanceof EntryEventMessagePayload);
+		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
+		Assert.assertEquals(EntryEventType.ADDED, msg.getHeaders().get(HazelcastHeaders.EVENT));
+		Assert.assertEquals("edMultiMap1", msg.getHeaders().get(HazelcastHeaders.NAME));
+
+		Assert.assertEquals(Integer.valueOf(1),
+				((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getKey());
 		Assert.assertEquals(1,
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getValue()).getId());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getValue()).getId());
 		Assert.assertEquals("TestName1",
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getValue()).getName());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getValue()).getName());
 		Assert.assertEquals("TestSurname1",
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getValue()).getSurname());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getValue()).getSurname());
 	}
 
 	@Test
@@ -92,18 +98,23 @@ public class HazelcastMultiMapEventDrivenInboundChannelAdapterTests {
 		Message<?> msg = edMultiMapChannel2.receive(2_000);
 		Assert.assertNotNull(msg);
 		Assert.assertNotNull(msg.getPayload());
-		Assert.assertTrue(msg.getPayload() instanceof EntryEvent);
-		Assert.assertEquals(EntryEventType.REMOVED,
-				((EntryEvent<?, ?>) msg.getPayload()).getEventType());
-		Assert.assertEquals("edMultiMap2",
-				((EntryEvent<?, ?>) msg.getPayload()).getName());
-		Assert.assertEquals(2, ((EntryEvent<?, ?>) msg.getPayload()).getKey());
+		Assert.assertTrue(msg.getPayload() instanceof EntryEventMessagePayload);
+		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
+		Assert.assertEquals(EntryEventType.REMOVED, msg.getHeaders().get(HazelcastHeaders.EVENT));
+		Assert.assertEquals("edMultiMap2", msg.getHeaders().get(HazelcastHeaders.NAME));
+
+		Assert.assertEquals(Integer.valueOf(2),
+				((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getKey());
 		Assert.assertEquals(2,
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getValue()).getId());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getValue()).getId());
 		Assert.assertEquals("TestName2",
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getValue()).getName());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getValue()).getName());
 		Assert.assertEquals("TestSurname2",
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getValue()).getSurname());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getValue()).getSurname());
 	}
 
 	@Test
@@ -131,12 +142,12 @@ public class HazelcastMultiMapEventDrivenInboundChannelAdapterTests {
 		verify(msg, "edMultiMap3", EntryEventType.CLEAR_ALL);
 	}
 
-	private void verify(Message<?> msg, String cacheName, EntryEventType type) {
+	private void verify(Message<?> msg, String cacheName, EntryEventType event) {
 		Assert.assertNotNull(msg);
 		Assert.assertNotNull(msg.getPayload());
-		Assert.assertTrue(msg.getPayload() instanceof AbstractIMapEvent);
-		Assert.assertEquals(cacheName, ((AbstractIMapEvent) msg.getPayload()).getName());
-		Assert.assertEquals(type, ((AbstractIMapEvent) msg.getPayload()).getEventType());
+		Assert.assertTrue(msg.getPayload() instanceof EntryEventMessagePayload);
+		Assert.assertEquals(cacheName, msg.getHeaders().get(HazelcastHeaders.NAME));
+		Assert.assertEquals(event, msg.getHeaders().get(HazelcastHeaders.EVENT));
 	}
 
 }

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastReplicatedMapEventDrivenInboundChannelAdapterTests.java
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastReplicatedMapEventDrivenInboundChannelAdapterTests.java
@@ -24,14 +24,14 @@ import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.hazelcast.HazelcastIntegrationTestUser;
+import org.springframework.integration.hazelcast.message.EntryEventMessagePayload;
+import org.springframework.integration.hazelcast.message.HazelcastHeaders;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import com.hazelcast.core.AbstractIMapEvent;
-import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.ReplicatedMap;
 
@@ -44,6 +44,7 @@ import com.hazelcast.core.ReplicatedMap;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
 @DirtiesContext
+@SuppressWarnings("unchecked")
 public class HazelcastReplicatedMapEventDrivenInboundChannelAdapterTests {
 
 	@Autowired
@@ -76,18 +77,23 @@ public class HazelcastReplicatedMapEventDrivenInboundChannelAdapterTests {
 		Message<?> msg = edReplicatedMapChannel1.receive(2_000);
 		Assert.assertNotNull(msg);
 		Assert.assertNotNull(msg.getPayload());
-		Assert.assertTrue(msg.getPayload() instanceof EntryEvent);
-		Assert.assertEquals(EntryEventType.ADDED,
-				((EntryEvent<?, ?>) msg.getPayload()).getEventType());
-		Assert.assertEquals("edReplicatedMap1",
-				((EntryEvent<?, ?>) msg.getPayload()).getName());
-		Assert.assertEquals(1, ((EntryEvent<?, ?>) msg.getPayload()).getKey());
+		Assert.assertTrue(msg.getPayload() instanceof EntryEventMessagePayload);
+		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
+		Assert.assertEquals(EntryEventType.ADDED, msg.getHeaders().get(HazelcastHeaders.EVENT));
+		Assert.assertEquals("edReplicatedMap1", msg.getHeaders().get(HazelcastHeaders.NAME));
+
+		Assert.assertEquals(Integer.valueOf(1),
+				((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getKey());
 		Assert.assertEquals(1,
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getValue()).getId());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getValue()).getId());
 		Assert.assertEquals("TestName1",
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getValue()).getName());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getValue()).getName());
 		Assert.assertEquals("TestSurname1",
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getValue()).getSurname());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getValue()).getSurname());
 	}
 
 	@Test
@@ -97,24 +103,33 @@ public class HazelcastReplicatedMapEventDrivenInboundChannelAdapterTests {
 		Message<?> msg = edReplicatedMapChannel2.receive(2_000);
 		Assert.assertNotNull(msg);
 		Assert.assertNotNull(msg.getPayload());
-		Assert.assertTrue(msg.getPayload() instanceof EntryEvent);
-		Assert.assertEquals(EntryEventType.UPDATED,
-				((EntryEvent<?, ?>) msg.getPayload()).getEventType());
-		Assert.assertEquals("edReplicatedMap2",
-				((EntryEvent<?, ?>) msg.getPayload()).getName());
-		Assert.assertEquals(2, ((EntryEvent<?, ?>) msg.getPayload()).getKey());
+
+		Assert.assertTrue(msg.getPayload() instanceof EntryEventMessagePayload);
+		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
+		Assert.assertEquals(EntryEventType.UPDATED, msg.getHeaders().get(HazelcastHeaders.EVENT));
+		Assert.assertEquals("edReplicatedMap2", msg.getHeaders().get(HazelcastHeaders.NAME));
+
+		Assert.assertEquals(Integer.valueOf(2),
+				((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getKey());
 		Assert.assertEquals(1,
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getOldValue()).getId());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getOldValue()).getId());
 		Assert.assertEquals("TestName1",
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getOldValue()).getName());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getOldValue()).getName());
 		Assert.assertEquals("TestSurname1",
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getOldValue()).getSurname());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getOldValue()).getSurname());
 		Assert.assertEquals(2,
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getValue()).getId());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getValue()).getId());
 		Assert.assertEquals("TestName2",
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getValue()).getName());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getValue()).getName());
 		Assert.assertEquals("TestSurname2",
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getValue()).getSurname());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getValue()).getSurname());
 	}
 
 	@Test
@@ -125,18 +140,23 @@ public class HazelcastReplicatedMapEventDrivenInboundChannelAdapterTests {
 		Message<?> msg = edReplicatedMapChannel3.receive(2_000);
 		Assert.assertNotNull(msg);
 		Assert.assertNotNull(msg.getPayload());
-		Assert.assertTrue(msg.getPayload() instanceof EntryEvent);
-		Assert.assertEquals(EntryEventType.REMOVED,
-				((EntryEvent<?, ?>) msg.getPayload()).getEventType());
-		Assert.assertEquals("edReplicatedMap3",
-				((EntryEvent<?, ?>) msg.getPayload()).getName());
-		Assert.assertEquals(2, ((EntryEvent<?, ?>) msg.getPayload()).getKey());
+		Assert.assertTrue(msg.getPayload() instanceof EntryEventMessagePayload);
+		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
+		Assert.assertEquals(EntryEventType.REMOVED, msg.getHeaders().get(HazelcastHeaders.EVENT));
+		Assert.assertEquals("edReplicatedMap3", msg.getHeaders().get(HazelcastHeaders.NAME));
+
+		Assert.assertEquals(Integer.valueOf(2),
+				((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getKey());
 		Assert.assertEquals(2,
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getOldValue()).getId());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getOldValue()).getId());
 		Assert.assertEquals("TestName2",
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getOldValue()).getName());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getOldValue()).getName());
 		Assert.assertEquals("TestSurname2",
-				((HazelcastIntegrationTestUser) ((EntryEvent<?, ?>) msg.getPayload()).getOldValue()).getSurname());
+				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
+						.getPayload()).getOldValue()).getSurname());
 	}
 
 	@Test
@@ -159,12 +179,12 @@ public class HazelcastReplicatedMapEventDrivenInboundChannelAdapterTests {
 
 	}
 
-	private void verify(Message<?> msg, String cacheName, EntryEventType type) {
+	private void verify(Message<?> msg, String cacheName, EntryEventType event) {
 		Assert.assertNotNull(msg);
 		Assert.assertNotNull(msg.getPayload());
-		Assert.assertTrue(msg.getPayload() instanceof AbstractIMapEvent);
-		Assert.assertEquals(cacheName, ((AbstractIMapEvent) msg.getPayload()).getName());
-		Assert.assertEquals(type, ((AbstractIMapEvent) msg.getPayload()).getEventType());
+		Assert.assertTrue(msg.getPayload() instanceof EntryEventMessagePayload);
+		Assert.assertEquals(cacheName, msg.getHeaders().get(HazelcastHeaders.NAME));
+		Assert.assertEquals(event, msg.getHeaders().get(HazelcastHeaders.EVENT));
 	}
 
 }

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastReplicatedMapEventDrivenInboundChannelAdapterTests.java
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastReplicatedMapEventDrivenInboundChannelAdapterTests.java
@@ -23,9 +23,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.integration.hazelcast.AbstractHazelcastTestSupport;
+import org.springframework.integration.hazelcast.HazelcastHeaders;
 import org.springframework.integration.hazelcast.HazelcastIntegrationTestUser;
 import org.springframework.integration.hazelcast.message.EntryEventMessagePayload;
-import org.springframework.integration.hazelcast.message.HazelcastHeaders;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.test.annotation.DirtiesContext;
@@ -45,7 +46,7 @@ import com.hazelcast.core.ReplicatedMap;
 @ContextConfiguration
 @DirtiesContext
 @SuppressWarnings("unchecked")
-public class HazelcastReplicatedMapEventDrivenInboundChannelAdapterTests {
+public class HazelcastReplicatedMapEventDrivenInboundChannelAdapterTests extends AbstractHazelcastTestSupport {
 
 	@Autowired
 	private PollableChannel edReplicatedMapChannel1;
@@ -79,21 +80,21 @@ public class HazelcastReplicatedMapEventDrivenInboundChannelAdapterTests {
 		Assert.assertNotNull(msg.getPayload());
 		Assert.assertTrue(msg.getPayload() instanceof EntryEventMessagePayload);
 		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
-		Assert.assertEquals(EntryEventType.ADDED, msg.getHeaders().get(HazelcastHeaders.EVENT));
-		Assert.assertEquals("edReplicatedMap1", msg.getHeaders().get(HazelcastHeaders.NAME));
+		Assert.assertEquals(EntryEventType.ADDED.name(), msg.getHeaders().get(HazelcastHeaders.EVENT_TYPE));
+		Assert.assertEquals("edReplicatedMap1", msg.getHeaders().get(HazelcastHeaders.CACHE_NAME));
 
 		Assert.assertEquals(Integer.valueOf(1),
 				((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getKey());
+						.getPayload()).key);
 		Assert.assertEquals(1,
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getValue()).getId());
+						.getPayload()).value).getId());
 		Assert.assertEquals("TestName1",
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getValue()).getName());
+						.getPayload()).value).getName());
 		Assert.assertEquals("TestSurname1",
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getValue()).getSurname());
+						.getPayload()).value).getSurname());
 	}
 
 	@Test
@@ -106,30 +107,30 @@ public class HazelcastReplicatedMapEventDrivenInboundChannelAdapterTests {
 
 		Assert.assertTrue(msg.getPayload() instanceof EntryEventMessagePayload);
 		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
-		Assert.assertEquals(EntryEventType.UPDATED, msg.getHeaders().get(HazelcastHeaders.EVENT));
-		Assert.assertEquals("edReplicatedMap2", msg.getHeaders().get(HazelcastHeaders.NAME));
+		Assert.assertEquals(EntryEventType.UPDATED.name(), msg.getHeaders().get(HazelcastHeaders.EVENT_TYPE));
+		Assert.assertEquals("edReplicatedMap2", msg.getHeaders().get(HazelcastHeaders.CACHE_NAME));
 
 		Assert.assertEquals(Integer.valueOf(2),
 				((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getKey());
+						.getPayload()).key);
 		Assert.assertEquals(1,
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getOldValue()).getId());
+						.getPayload()).oldValue).getId());
 		Assert.assertEquals("TestName1",
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getOldValue()).getName());
+						.getPayload()).oldValue).getName());
 		Assert.assertEquals("TestSurname1",
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getOldValue()).getSurname());
+						.getPayload()).oldValue).getSurname());
 		Assert.assertEquals(2,
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getValue()).getId());
+						.getPayload()).value).getId());
 		Assert.assertEquals("TestName2",
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getValue()).getName());
+						.getPayload()).value).getName());
 		Assert.assertEquals("TestSurname2",
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getValue()).getSurname());
+						.getPayload()).value).getSurname());
 	}
 
 	@Test
@@ -142,49 +143,41 @@ public class HazelcastReplicatedMapEventDrivenInboundChannelAdapterTests {
 		Assert.assertNotNull(msg.getPayload());
 		Assert.assertTrue(msg.getPayload() instanceof EntryEventMessagePayload);
 		Assert.assertNotNull(msg.getHeaders().get(HazelcastHeaders.MEMBER));
-		Assert.assertEquals(EntryEventType.REMOVED, msg.getHeaders().get(HazelcastHeaders.EVENT));
-		Assert.assertEquals("edReplicatedMap3", msg.getHeaders().get(HazelcastHeaders.NAME));
+		Assert.assertEquals(EntryEventType.REMOVED.name(), msg.getHeaders().get(HazelcastHeaders.EVENT_TYPE));
+		Assert.assertEquals("edReplicatedMap3", msg.getHeaders().get(HazelcastHeaders.CACHE_NAME));
 
 		Assert.assertEquals(Integer.valueOf(2),
 				((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getKey());
+						.getPayload()).key);
 		Assert.assertEquals(2,
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getOldValue()).getId());
+						.getPayload()).oldValue).getId());
 		Assert.assertEquals("TestName2",
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getOldValue()).getName());
+						.getPayload()).oldValue).getName());
 		Assert.assertEquals("TestSurname2",
 				(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-						.getPayload()).getOldValue()).getSurname());
+						.getPayload()).oldValue).getSurname());
 	}
 
 	@Test
 	public void testEventDrivenForALLEntryEvent() {
 		edReplicatedMap4.put(1, new HazelcastIntegrationTestUser(1, "TestName1", "TestSurname1"));
 		Message<?> msg = edReplicatedMapChannel4.receive(2_000);
-		verify(msg, "edReplicatedMap4", EntryEventType.ADDED);
+		verifyEntryEvent(msg, "edReplicatedMap4", EntryEventType.ADDED);
 
 		edReplicatedMap4.put(1, new HazelcastIntegrationTestUser(1, "TestName1", "TestSurnameUpdated"));
 		msg = edReplicatedMapChannel4.receive(2_000);
-		verify(msg, "edReplicatedMap4", EntryEventType.UPDATED);
+		verifyEntryEvent(msg, "edReplicatedMap4", EntryEventType.UPDATED);
 
 		edReplicatedMap4.remove(1);
 		msg = edReplicatedMapChannel4.receive(2_000);
-		verify(msg, "edReplicatedMap4", EntryEventType.REMOVED);
+		verifyEntryEvent(msg, "edReplicatedMap4", EntryEventType.REMOVED);
 
 		edReplicatedMap4.put(2, new HazelcastIntegrationTestUser(2, "TestName2", "TestSurname2"));
 		msg = edReplicatedMapChannel4.receive(2_000);
-		verify(msg, "edReplicatedMap4", EntryEventType.ADDED);
+		verifyEntryEvent(msg, "edReplicatedMap4", EntryEventType.ADDED);
 
-	}
-
-	private void verify(Message<?> msg, String cacheName, EntryEventType event) {
-		Assert.assertNotNull(msg);
-		Assert.assertNotNull(msg.getPayload());
-		Assert.assertTrue(msg.getPayload() instanceof EntryEventMessagePayload);
-		Assert.assertEquals(cacheName, msg.getHeaders().get(HazelcastHeaders.NAME));
-		Assert.assertEquals(event, msg.getHeaders().get(HazelcastHeaders.EVENT));
 	}
 
 }


### PR DESCRIPTION
**JIRA :** https://jira.spring.io/browse/INTEXT-150

This feature has been developed to support more meaningful Hazelcast Headers and Payloads.

**All Hazelcast Headers :** event, member, name and publishingTime

**For EntryEvent :**
Header : event, member and name.
Payload : key, oldValue and value(EntryEventMessagePayload object has been created to cover these fields)

**For MapEvent :**
Header : event, member and name.
Payload : numberOfEntriesAffected (EntryEventMessagePayload object has been created to cover this field)

**For ItemEvent :**
Header : event and member.
Payload : item

**For MessageEvent :**
Header : member, name and publishingTime
Payload : message