### PR TITLE
INTEXT-149 : Provide logic for the HazelcastCacheWritingMessageHandler to accept single entry

### DIFF
--- a/spring-integration-hazelcast/build.gradle
+++ b/spring-integration-hazelcast/build.gradle
@@ -17,7 +17,7 @@ ext {
 	hazelcastVersion = '3.4.2'
 	jacocoVersion = '0.7.2.201409121644'
 	slf4jVersion = '1.7.10'
-	springIntegrationVersion = '4.1.2.RELEASE'
+	springIntegrationVersion = '4.1.3.RELEASE'
 
 	idPrefix = 'hazelcast'
 

--- a/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/HazelcastIntegrationDefinitionValidator.java
+++ b/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/HazelcastIntegrationDefinitionValidator.java
@@ -61,17 +61,6 @@ public class HazelcastIntegrationDefinitionValidator {
 		}
 	}
 
-	public static void validateCacheTypeForCacheWritingMessageHandler(final DistributedObject distributedObject) {
-		if (!(distributedObject instanceof IMap
-				|| distributedObject instanceof IList
-				|| distributedObject instanceof ISet
-				|| distributedObject instanceof IQueue)) {
-			throw new IllegalArgumentException(
-					"Invalid 'cache' type is set. IMap, IList, ISet and IQueue cache object types are acceptable "
-							+ "for Hazelcast Outbound Channel Adapter.");
-		}
-	}
-
 	public static void validateCacheEventsByDistributedObject(
 			final DistributedObject distributedObject, final Set<String> cacheEventTypeSet) {
 		List<String> supportedCacheEventTypes = getSupportedCacheEventTypes(distributedObject);

--- a/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/config/xml/HazelcastOutboundChannelAdapterParser.java
+++ b/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/config/xml/HazelcastOutboundChannelAdapterParser.java
@@ -22,12 +22,12 @@ import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.xml.AbstractOutboundChannelAdapterParser;
+import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
 import org.springframework.integration.hazelcast.outbound.HazelcastCacheWritingMessageHandler;
 
-import reactor.util.StringUtils;
-
 /**
- * Hazelcast Outbound Channel Adapter Parser for {@code <int-hazelcast:inbound-channel-adapter />}.
+ * Hazelcast Outbound Channel Adapter Parser for
+ * {@code <int-hazelcast:inbound-channel-adapter />}.
  *
  * @author Eren Avsarogullari
  * @since 1.0.0
@@ -36,16 +36,27 @@ public class HazelcastOutboundChannelAdapterParser extends AbstractOutboundChann
 
 	private static final String CACHE_ATTRIBUTE = "cache";
 
+	private static final String CACHE_EXPRESSION_ATTRIBUTE = "cache-expression";
+
+	private static final String KEY_EXPRESSION_ATTRIBUTE = "key-expression";
+
+	private static final String EXTRACT_PAYLOAD_ATTRIBUTE = "extract-payload";
+
+	private static final String DISTRIBUTED_OBJECT = "distributedObject";
+
 	@Override
 	protected AbstractBeanDefinition parseConsumer(Element element, ParserContext parserContext) {
 		BeanDefinitionBuilder builder = BeanDefinitionBuilder
 				.genericBeanDefinition(HazelcastCacheWritingMessageHandler.class);
 
-		if (!StringUtils.hasText(element.getAttribute(CACHE_ATTRIBUTE))) {
-			parserContext.getReaderContext().error("'" + CACHE_ATTRIBUTE + "' attribute is required.", element);
-		}
-
-		builder.addConstructorArgReference(element.getAttribute(CACHE_ATTRIBUTE));
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element,
+				CACHE_ATTRIBUTE, DISTRIBUTED_OBJECT);
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element,
+				CACHE_EXPRESSION_ATTRIBUTE);
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element,
+				KEY_EXPRESSION_ATTRIBUTE);
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element,
+				EXTRACT_PAYLOAD_ATTRIBUTE);
 
 		return builder.getBeanDefinition();
 	}

--- a/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/config/xml/HazelcastOutboundChannelAdapterParser.java
+++ b/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/config/xml/HazelcastOutboundChannelAdapterParser.java
@@ -18,6 +18,7 @@ package org.springframework.integration.hazelcast.config.xml;
 
 import org.w3c.dom.Element;
 
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
@@ -51,10 +52,16 @@ public class HazelcastOutboundChannelAdapterParser extends AbstractOutboundChann
 
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element,
 				CACHE_ATTRIBUTE, DISTRIBUTED_OBJECT);
-		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element,
-				CACHE_EXPRESSION_ATTRIBUTE);
-		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element,
-				KEY_EXPRESSION_ATTRIBUTE);
+		BeanDefinition cacheExpressionDef = IntegrationNamespaceUtils.createExpressionDefIfAttributeDefined(CACHE_EXPRESSION_ATTRIBUTE, element);
+		if (cacheExpressionDef != null) {
+			builder.addPropertyValue("cacheExpression", cacheExpressionDef);
+		}
+
+		BeanDefinition keyExpressionDef = IntegrationNamespaceUtils.createExpressionDefIfAttributeDefined(KEY_EXPRESSION_ATTRIBUTE, element);
+		if (keyExpressionDef != null) {
+			builder.addPropertyValue("keyExpression", keyExpressionDef);
+		}
+
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element,
 				EXTRACT_PAYLOAD_ATTRIBUTE);
 

--- a/spring-integration-hazelcast/src/main/resources/org/springframework/integration/hazelcast/config/xml/spring-integration-hazelcast-1.0.xsd
+++ b/spring-integration-hazelcast/src/main/resources/org/springframework/integration/hazelcast/config/xml/spring-integration-hazelcast-1.0.xsd
@@ -84,7 +84,7 @@
 
  			<xsd:attributeGroup ref="integration:channelAdapterAttributes"/>
 
-			<xsd:attribute name="cache" use="required" type="xsd:string">
+			<xsd:attribute name="cache" type="xsd:string" use="optional">
 				<xsd:annotation>
 					<xsd:appinfo>
 						<tool:annotation kind="ref">
@@ -93,6 +93,30 @@
 					</xsd:appinfo>
 					<xsd:documentation>
 						<![CDATA[ Specifies cache reference to listen ]]>
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			
+			<xsd:attribute name="cache-expression" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						<![CDATA[ Specifies cache name to listen ]]>
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			
+			<xsd:attribute name="key-expression" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						<![CDATA[ Specifies entry key ]]>
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			
+			<xsd:attribute name="extract-payload" type="xsd:boolean" default="true">
+				<xsd:annotation>
+					<xsd:documentation>
+						<![CDATA[ Specifies whole message or just payload to send ]]>
 					</xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/HazelcastIntegrationTestUser.java
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/HazelcastIntegrationTestUser.java
@@ -24,7 +24,7 @@ import java.io.Serializable;
  * @author Eren Avsarogullari
  * @since 1.0.0
  */
-public class HazelcastIntegrationTestUser implements Serializable {
+public class HazelcastIntegrationTestUser implements Comparable<HazelcastIntegrationTestUser>, Serializable {
 
 	private static final long serialVersionUID = -5357485957528362705L;
 
@@ -124,6 +124,11 @@ public class HazelcastIntegrationTestUser implements Serializable {
 		else if (!surname.equals(other.surname))
 			return false;
 		return true;
+	}
+
+	@Override
+	public int compareTo(HazelcastIntegrationTestUser user) {
+		return (this.id < user.getId()) ? -1: (this.id > user.getId()) ? 1 : 0;
 	}
 
 }

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/HazelcastTestRequestHandlerAdvice.java
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/HazelcastTestRequestHandlerAdvice.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.hazelcast;
+
+import java.util.concurrent.CountDownLatch;
+
+import org.springframework.integration.handler.advice.AbstractRequestHandlerAdvice;
+import org.springframework.messaging.Message;
+
+/**
+ * {@link MessageHandler} advice class for Hazelcast Integration Unit Tests.
+ *
+ * @author Eren Avsarogullari
+ * @since 1.0.0
+ */
+public class HazelcastTestRequestHandlerAdvice  extends AbstractRequestHandlerAdvice {
+
+	public CountDownLatch executeLatch = null;
+
+	public HazelcastTestRequestHandlerAdvice(int count) {
+		this.executeLatch = new CountDownLatch(count);
+	}
+
+	@Override
+	protected Object doInvoke(ExecutionCallback callback, Object target, Message<?> message) throws Exception {
+		try {
+			return callback.execute();
+		}
+		finally {
+			this.executeLatch.countDown();
+		}
+	}
+
+}

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/outbound/HazelcastOutboundChannelAdapterTests-context.xml
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/outbound/HazelcastOutboundChannelAdapterTests-context.xml
@@ -22,24 +22,36 @@
 	
 	<int:channel id="sixthMapChannel"/>
 	
+	<int:channel id="bulkMapChannel"/>
+	
 	<int:channel id="multiMapChannel"/>
 	
 	<int:channel id="replicatedMapChannel"/>
+	
+	<int:channel id="bulkReplicatedMapChannel"/>
 
 	<int:channel id="listChannel"/>
+	
+	<int:channel id="bulkListChannel"/>
 
 	<int:channel id="setChannel"/>
+	
+	<int:channel id="bulkSetChannel"/>
 
 	<int:channel id="queueChannel">
 		<int:queue/>
 	</int:channel>
 	
+	<int:channel id="bulkQueueChannel">
+		<int:queue/>
+	</int:channel>
+	
 	<int:channel id="topicChannel"/>
-	
-	<int:channel id="differentDistributedObjectsChannel"/>
-	
+		
 	<bean id="testFirstMapRequestHandlerAdvice"
-		  class="org.springframework.integration.hazelcast.outbound.HazelcastOutboundChannelAdapterTests$TestRequestHandlerAdvice"/>
+		  class="org.springframework.integration.hazelcast.HazelcastTestRequestHandlerAdvice">
+		<constructor-arg type="int" value="100"/>
+	</bean>
 	
 	<int-hazelcast:outbound-channel-adapter channel="firstMapChannel" cache="distributedMap" key-expression="payload.id">
 		<int-hazelcast:request-handler-advice-chain>
@@ -48,16 +60,20 @@
 	</int-hazelcast:outbound-channel-adapter>
 	
 	<bean id="testSecondMapRequestHandlerAdvice"
-		  class="org.springframework.integration.hazelcast.outbound.HazelcastOutboundChannelAdapterTests$TestRequestHandlerAdvice"/>
+		  class="org.springframework.integration.hazelcast.HazelcastTestRequestHandlerAdvice">
+		<constructor-arg type="int" value="100"/>
+	</bean>
 	
-	<int-hazelcast:outbound-channel-adapter channel="secondMapChannel" cache-expression="headers['CACHE_HEADER']" key-expression="payload.id">
+	<int-hazelcast:outbound-channel-adapter channel="secondMapChannel" cache-expression="@distributedMap" key-expression="payload.id">
 		<int-hazelcast:request-handler-advice-chain>
 			<ref bean="testSecondMapRequestHandlerAdvice"/>
 		</int-hazelcast:request-handler-advice-chain>
 	</int-hazelcast:outbound-channel-adapter>
 	
 	<bean id="testThirdMapRequestHandlerAdvice"
-		  class="org.springframework.integration.hazelcast.outbound.HazelcastOutboundChannelAdapterTests$TestRequestHandlerAdvice"/>
+		  class="org.springframework.integration.hazelcast.HazelcastTestRequestHandlerAdvice">
+		<constructor-arg type="int" value="100"/>
+	</bean>
 	
 	<int-hazelcast:outbound-channel-adapter channel="thirdMapChannel" key-expression="payload.id">
 		<int-hazelcast:request-handler-advice-chain>
@@ -66,7 +82,9 @@
 	</int-hazelcast:outbound-channel-adapter>
 	
 	<bean id="testFourthMapRequestHandlerAdvice"
-		  class="org.springframework.integration.hazelcast.outbound.HazelcastOutboundChannelAdapterTests$TestRequestHandlerAdvice"/>
+		  class="org.springframework.integration.hazelcast.HazelcastTestRequestHandlerAdvice">
+		<constructor-arg type="int" value="100"/>
+	</bean>
 	
 	<int-hazelcast:outbound-channel-adapter channel="fourthMapChannel" key-expression="payload.id" extract-payload="false">
 		<int-hazelcast:request-handler-advice-chain>
@@ -78,8 +96,21 @@
 	
 	<int-hazelcast:outbound-channel-adapter channel="sixthMapChannel" />
 	
+	<bean id="testBulkMapRequestHandlerAdvice"
+		  class="org.springframework.integration.hazelcast.HazelcastTestRequestHandlerAdvice">
+		<constructor-arg type="int" value="1"/>
+	</bean>
+	
+	<int-hazelcast:outbound-channel-adapter channel="bulkMapChannel" cache="distributedBulkMap" key-expression="payload.id">
+		<int-hazelcast:request-handler-advice-chain>
+			<ref bean="testBulkMapRequestHandlerAdvice"/>
+		</int-hazelcast:request-handler-advice-chain>
+	</int-hazelcast:outbound-channel-adapter>
+	
 	<bean id="testMultiMapRequestHandlerAdvice"
-		  class="org.springframework.integration.hazelcast.outbound.HazelcastOutboundChannelAdapterTests$TestRequestHandlerAdvice"/>
+		  class="org.springframework.integration.hazelcast.HazelcastTestRequestHandlerAdvice">
+		<constructor-arg type="int" value="100"/>
+	</bean>
 	
 	<int-hazelcast:outbound-channel-adapter channel="multiMapChannel" cache="multiMap" key-expression="payload.id">
 		<int-hazelcast:request-handler-advice-chain>
@@ -88,7 +119,9 @@
 	</int-hazelcast:outbound-channel-adapter>
 	
 	<bean id="testReplicatedMapRequestHandlerAdvice"
-		  class="org.springframework.integration.hazelcast.outbound.HazelcastOutboundChannelAdapterTests$TestRequestHandlerAdvice"/>
+		  class="org.springframework.integration.hazelcast.HazelcastTestRequestHandlerAdvice">
+		<constructor-arg type="int" value="100"/>
+	</bean>
 	
 	<int-hazelcast:outbound-channel-adapter channel="replicatedMapChannel" cache="replicatedMap" key-expression="payload.id">
 		<int-hazelcast:request-handler-advice-chain>
@@ -96,8 +129,21 @@
 		</int-hazelcast:request-handler-advice-chain>
 	</int-hazelcast:outbound-channel-adapter>
 	
+	<bean id="testBulkReplicatedMapRequestHandlerAdvice"
+		  class="org.springframework.integration.hazelcast.HazelcastTestRequestHandlerAdvice">
+		<constructor-arg type="int" value="1"/>
+	</bean>
+	
+	<int-hazelcast:outbound-channel-adapter channel="bulkReplicatedMapChannel" cache="bulkReplicatedMap" key-expression="payload.id">
+		<int-hazelcast:request-handler-advice-chain>
+			<ref bean="testBulkReplicatedMapRequestHandlerAdvice"/>
+		</int-hazelcast:request-handler-advice-chain>
+	</int-hazelcast:outbound-channel-adapter>
+	
 	<bean id="testListRequestHandlerAdvice"
-		  class="org.springframework.integration.hazelcast.outbound.HazelcastOutboundChannelAdapterTests$TestRequestHandlerAdvice"/>
+		  class="org.springframework.integration.hazelcast.HazelcastTestRequestHandlerAdvice">
+		<constructor-arg type="int" value="100"/>
+	</bean>
 	
 	<int-hazelcast:outbound-channel-adapter channel="listChannel" cache="distributedList">
 		<int-hazelcast:request-handler-advice-chain>
@@ -105,8 +151,21 @@
 		</int-hazelcast:request-handler-advice-chain>
 	</int-hazelcast:outbound-channel-adapter>
 	
+	<bean id="testBulkListRequestHandlerAdvice"
+		  class="org.springframework.integration.hazelcast.HazelcastTestRequestHandlerAdvice">
+		  <constructor-arg type="int" value="1"/>
+	</bean>
+	
+	<int-hazelcast:outbound-channel-adapter channel="bulkListChannel" cache="distributedBulkList">
+		<int-hazelcast:request-handler-advice-chain>
+			<ref bean="testBulkListRequestHandlerAdvice"/>
+		</int-hazelcast:request-handler-advice-chain>
+	</int-hazelcast:outbound-channel-adapter>
+	
 	<bean id="testSetRequestHandlerAdvice"
-		  class="org.springframework.integration.hazelcast.outbound.HazelcastOutboundChannelAdapterTests$TestRequestHandlerAdvice"/>
+		  class="org.springframework.integration.hazelcast.HazelcastTestRequestHandlerAdvice">
+		<constructor-arg type="int" value="100"/>
+	</bean>
 	
 	<int-hazelcast:outbound-channel-adapter channel="setChannel" cache="distributedSet" >
 		<int-hazelcast:request-handler-advice-chain>
@@ -114,8 +173,21 @@
 		</int-hazelcast:request-handler-advice-chain>
 	</int-hazelcast:outbound-channel-adapter>
 	
+	<bean id="testBulkSetRequestHandlerAdvice"
+		  class="org.springframework.integration.hazelcast.HazelcastTestRequestHandlerAdvice">
+		<constructor-arg type="int" value="1"/>
+	</bean>
+	
+	<int-hazelcast:outbound-channel-adapter channel="bulkSetChannel" cache="distributedBulkSet" >
+		<int-hazelcast:request-handler-advice-chain>
+			<ref bean="testBulkSetRequestHandlerAdvice"/>
+		</int-hazelcast:request-handler-advice-chain>
+	</int-hazelcast:outbound-channel-adapter>
+	
 	<bean id="testQueueRequestHandlerAdvice"
-		  class="org.springframework.integration.hazelcast.outbound.HazelcastOutboundChannelAdapterTests$TestRequestHandlerAdvice"/>
+		  class="org.springframework.integration.hazelcast.HazelcastTestRequestHandlerAdvice">
+		<constructor-arg type="int" value="100"/>
+	</bean>
 
 	<int-hazelcast:outbound-channel-adapter channel="queueChannel" cache="distributedQueue">
 		<int:poller fixed-delay="100"/>
@@ -124,8 +196,22 @@
 		</int-hazelcast:request-handler-advice-chain>
 	</int-hazelcast:outbound-channel-adapter>
 	
+	<bean id="testBulkQueueRequestHandlerAdvice"
+		  class="org.springframework.integration.hazelcast.HazelcastTestRequestHandlerAdvice">
+		<constructor-arg type="int" value="1"/>
+	</bean>
+
+	<int-hazelcast:outbound-channel-adapter channel="bulkQueueChannel" cache="distributedBulkQueue">
+		<int:poller fixed-delay="100"/>
+		<int-hazelcast:request-handler-advice-chain>
+			<ref bean="testBulkQueueRequestHandlerAdvice"/>
+		</int-hazelcast:request-handler-advice-chain>
+	</int-hazelcast:outbound-channel-adapter>
+	
 	<bean id="testTopicRequestHandlerAdvice"
-		  class="org.springframework.integration.hazelcast.outbound.HazelcastOutboundChannelAdapterTests$TestRequestHandlerAdvice"/>
+		  class="org.springframework.integration.hazelcast.HazelcastTestRequestHandlerAdvice">
+		<constructor-arg type="int" value="100" />
+	</bean>
 	
 	<int-hazelcast:outbound-channel-adapter channel="topicChannel" cache="topic" >
 		<int-hazelcast:request-handler-advice-chain>
@@ -133,24 +219,36 @@
 		</int-hazelcast:request-handler-advice-chain>
 	</int-hazelcast:outbound-channel-adapter>
 	
-	<int-hazelcast:outbound-channel-adapter channel="differentDistributedObjectsChannel" 
-											cache-expression="headers['CACHE_HEADER']" 
-											key-expression="payload.id" />
-
 	<bean id="distributedMap" factory-bean="instance" factory-method="getMap">
 		<constructor-arg value="distributedMap"/>
+	</bean>
+	
+	<bean id="distributedBulkMap" factory-bean="instance" factory-method="getMap">
+		<constructor-arg value="distributedBulkMap"/>
 	</bean>
 
 	<bean id="distributedList" factory-bean="instance" factory-method="getList">
 		<constructor-arg value="distributedList"/>
 	</bean>
+	
+	<bean id="distributedBulkList" factory-bean="instance" factory-method="getList">
+		<constructor-arg value="distributedBulkList"/>
+	</bean>
 
 	<bean id="distributedSet" factory-bean="instance" factory-method="getSet">
 		<constructor-arg value="distributedSet"/>
 	</bean>
+	
+	<bean id="distributedBulkSet" factory-bean="instance" factory-method="getSet">
+		<constructor-arg value="distributedBulkSet"/>
+	</bean>
 
 	<bean id="distributedQueue" factory-bean="instance" factory-method="getQueue">
 		<constructor-arg value="distributedQueue"/>
+	</bean>
+	
+	<bean id="distributedBulkQueue" factory-bean="instance" factory-method="getQueue">
+		<constructor-arg value="distributedBulkQueue"/>
 	</bean>
 	
 	<bean id="multiMap" factory-bean="instance" factory-method="getMultiMap">
@@ -159,6 +257,10 @@
 	
 	<bean id="replicatedMap" factory-bean="instance" factory-method="getReplicatedMap">
 		<constructor-arg value="replicatedMap"/>
+	</bean>
+	
+	<bean id="bulkReplicatedMap" factory-bean="instance" factory-method="getReplicatedMap">
+		<constructor-arg value="bulkReplicatedMap"/>
 	</bean>
 
 	<bean id="topic" factory-bean="instance" factory-method="getTopic">

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/outbound/HazelcastOutboundChannelAdapterTests-context.xml
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/outbound/HazelcastOutboundChannelAdapterTests-context.xml
@@ -10,7 +10,21 @@
     http://www.springframework.org/schema/integration/hazelcast
 	http://www.springframework.org/schema/integration/hazelcast/spring-integration-hazelcast.xsd">
 
-	<int:channel id="mapChannel"/>
+	<int:channel id="firstMapChannel"/>
+	
+	<int:channel id="secondMapChannel"/>
+	
+	<int:channel id="thirdMapChannel"/>
+	
+	<int:channel id="fourthMapChannel"/>
+	
+	<int:channel id="fifthMapChannel"/>
+	
+	<int:channel id="sixthMapChannel"/>
+	
+	<int:channel id="multiMapChannel"/>
+	
+	<int:channel id="replicatedMapChannel"/>
 
 	<int:channel id="listChannel"/>
 
@@ -19,26 +33,109 @@
 	<int:channel id="queueChannel">
 		<int:queue/>
 	</int:channel>
-
-	<int:channel id="errorChannel">
-		<int:queue/>
-	</int:channel>
-
-	<int-hazelcast:outbound-channel-adapter channel="mapChannel" cache="distributedMap"/>
-
-	<int-hazelcast:outbound-channel-adapter channel="listChannel" cache="distributedList"/>
-
-	<int-hazelcast:outbound-channel-adapter channel="setChannel" cache="distributedSet"/>
-
-	<bean id="testRequestHandlerAdvice"
+	
+	<int:channel id="topicChannel"/>
+	
+	<int:channel id="differentDistributedObjectsChannel"/>
+	
+	<bean id="testFirstMapRequestHandlerAdvice"
+		  class="org.springframework.integration.hazelcast.outbound.HazelcastOutboundChannelAdapterTests$TestRequestHandlerAdvice"/>
+	
+	<int-hazelcast:outbound-channel-adapter channel="firstMapChannel" cache="distributedMap" key-expression="payload.id">
+		<int-hazelcast:request-handler-advice-chain>
+			<ref bean="testFirstMapRequestHandlerAdvice"/>
+		</int-hazelcast:request-handler-advice-chain>
+	</int-hazelcast:outbound-channel-adapter>
+	
+	<bean id="testSecondMapRequestHandlerAdvice"
+		  class="org.springframework.integration.hazelcast.outbound.HazelcastOutboundChannelAdapterTests$TestRequestHandlerAdvice"/>
+	
+	<int-hazelcast:outbound-channel-adapter channel="secondMapChannel" cache-expression="headers['CACHE_HEADER']" key-expression="payload.id">
+		<int-hazelcast:request-handler-advice-chain>
+			<ref bean="testSecondMapRequestHandlerAdvice"/>
+		</int-hazelcast:request-handler-advice-chain>
+	</int-hazelcast:outbound-channel-adapter>
+	
+	<bean id="testThirdMapRequestHandlerAdvice"
+		  class="org.springframework.integration.hazelcast.outbound.HazelcastOutboundChannelAdapterTests$TestRequestHandlerAdvice"/>
+	
+	<int-hazelcast:outbound-channel-adapter channel="thirdMapChannel" key-expression="payload.id">
+		<int-hazelcast:request-handler-advice-chain>
+			<ref bean="testThirdMapRequestHandlerAdvice"/>
+		</int-hazelcast:request-handler-advice-chain>
+	</int-hazelcast:outbound-channel-adapter>
+	
+	<bean id="testFourthMapRequestHandlerAdvice"
+		  class="org.springframework.integration.hazelcast.outbound.HazelcastOutboundChannelAdapterTests$TestRequestHandlerAdvice"/>
+	
+	<int-hazelcast:outbound-channel-adapter channel="fourthMapChannel" key-expression="payload.id" extract-payload="false">
+		<int-hazelcast:request-handler-advice-chain>
+			<ref bean="testFourthMapRequestHandlerAdvice"/>
+		</int-hazelcast:request-handler-advice-chain>
+	</int-hazelcast:outbound-channel-adapter>
+	
+	<int-hazelcast:outbound-channel-adapter channel="fifthMapChannel" key-expression="payload.id" />
+	
+	<int-hazelcast:outbound-channel-adapter channel="sixthMapChannel" />
+	
+	<bean id="testMultiMapRequestHandlerAdvice"
+		  class="org.springframework.integration.hazelcast.outbound.HazelcastOutboundChannelAdapterTests$TestRequestHandlerAdvice"/>
+	
+	<int-hazelcast:outbound-channel-adapter channel="multiMapChannel" cache="multiMap" key-expression="payload.id">
+		<int-hazelcast:request-handler-advice-chain>
+			<ref bean="testMultiMapRequestHandlerAdvice"/>
+		</int-hazelcast:request-handler-advice-chain>
+	</int-hazelcast:outbound-channel-adapter>
+	
+	<bean id="testReplicatedMapRequestHandlerAdvice"
+		  class="org.springframework.integration.hazelcast.outbound.HazelcastOutboundChannelAdapterTests$TestRequestHandlerAdvice"/>
+	
+	<int-hazelcast:outbound-channel-adapter channel="replicatedMapChannel" cache="replicatedMap" key-expression="payload.id">
+		<int-hazelcast:request-handler-advice-chain>
+			<ref bean="testReplicatedMapRequestHandlerAdvice"/>
+		</int-hazelcast:request-handler-advice-chain>
+	</int-hazelcast:outbound-channel-adapter>
+	
+	<bean id="testListRequestHandlerAdvice"
+		  class="org.springframework.integration.hazelcast.outbound.HazelcastOutboundChannelAdapterTests$TestRequestHandlerAdvice"/>
+	
+	<int-hazelcast:outbound-channel-adapter channel="listChannel" cache="distributedList">
+		<int-hazelcast:request-handler-advice-chain>
+			<ref bean="testListRequestHandlerAdvice"/>
+		</int-hazelcast:request-handler-advice-chain>
+	</int-hazelcast:outbound-channel-adapter>
+	
+	<bean id="testSetRequestHandlerAdvice"
+		  class="org.springframework.integration.hazelcast.outbound.HazelcastOutboundChannelAdapterTests$TestRequestHandlerAdvice"/>
+	
+	<int-hazelcast:outbound-channel-adapter channel="setChannel" cache="distributedSet" >
+		<int-hazelcast:request-handler-advice-chain>
+			<ref bean="testSetRequestHandlerAdvice"/>
+		</int-hazelcast:request-handler-advice-chain>
+	</int-hazelcast:outbound-channel-adapter>
+	
+	<bean id="testQueueRequestHandlerAdvice"
 		  class="org.springframework.integration.hazelcast.outbound.HazelcastOutboundChannelAdapterTests$TestRequestHandlerAdvice"/>
 
 	<int-hazelcast:outbound-channel-adapter channel="queueChannel" cache="distributedQueue">
 		<int:poller fixed-delay="100"/>
 		<int-hazelcast:request-handler-advice-chain>
-			<ref bean="testRequestHandlerAdvice"/>
+			<ref bean="testQueueRequestHandlerAdvice"/>
 		</int-hazelcast:request-handler-advice-chain>
 	</int-hazelcast:outbound-channel-adapter>
+	
+	<bean id="testTopicRequestHandlerAdvice"
+		  class="org.springframework.integration.hazelcast.outbound.HazelcastOutboundChannelAdapterTests$TestRequestHandlerAdvice"/>
+	
+	<int-hazelcast:outbound-channel-adapter channel="topicChannel" cache="topic" >
+		<int-hazelcast:request-handler-advice-chain>
+			<ref bean="testTopicRequestHandlerAdvice"/>
+		</int-hazelcast:request-handler-advice-chain>
+	</int-hazelcast:outbound-channel-adapter>
+	
+	<int-hazelcast:outbound-channel-adapter channel="differentDistributedObjectsChannel" 
+											cache-expression="headers['CACHE_HEADER']" 
+											key-expression="payload.id" />
 
 	<bean id="distributedMap" factory-bean="instance" factory-method="getMap">
 		<constructor-arg value="distributedMap"/>
@@ -55,7 +152,19 @@
 	<bean id="distributedQueue" factory-bean="instance" factory-method="getQueue">
 		<constructor-arg value="distributedQueue"/>
 	</bean>
+	
+	<bean id="multiMap" factory-bean="instance" factory-method="getMultiMap">
+		<constructor-arg value="multiMap"/>
+	</bean>
+	
+	<bean id="replicatedMap" factory-bean="instance" factory-method="getReplicatedMap">
+		<constructor-arg value="replicatedMap"/>
+	</bean>
 
+	<bean id="topic" factory-bean="instance" factory-method="getTopic">
+		<constructor-arg value="topic"/>
+	</bean>
+	
 	<bean id="instance" class="com.hazelcast.core.Hazelcast" factory-method="newHazelcastInstance"
 		  destroy-method="shutdown">
 		<constructor-arg>

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/outbound/HazelcastOutboundChannelAdapterTests.java
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/outbound/HazelcastOutboundChannelAdapterTests.java
@@ -23,6 +23,8 @@ import static org.junit.Assert.assertTrue;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -31,7 +33,7 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Resource;
@@ -42,9 +44,9 @@ import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.integration.handler.advice.AbstractRequestHandlerAdvice;
 import org.springframework.integration.hazelcast.HazelcastHeaders;
 import org.springframework.integration.hazelcast.HazelcastIntegrationTestUser;
+import org.springframework.integration.hazelcast.HazelcastTestRequestHandlerAdvice;
 import org.springframework.integration.support.DefaultMessageBuilderFactory;
 import org.springframework.integration.support.MessageBuilderFactory;
 import org.springframework.messaging.Message;
@@ -83,55 +85,83 @@ public class HazelcastOutboundChannelAdapterTests {
 
 	private static final String DISTRIBUTED_MAP = "distributedMap";
 
-	private static final String DISTRIBUTED_LIST = "distributedList";
-
-	private static final String DISTRIBUTED_QUEUE = "distributedQueue";
-
 	private static final String CACHE_HEADER = "CACHE_HEADER";
 
 	private final MessageBuilderFactory messageBuilderFactory = new DefaultMessageBuilderFactory();
 
 	@Autowired
+	@Qualifier("firstMapChannel")
 	private MessageChannel firstMapChannel;
 
 	@Autowired
+	@Qualifier("secondMapChannel")
 	private MessageChannel secondMapChannel;
 
 	@Autowired
+	@Qualifier("thirdMapChannel")
 	private MessageChannel thirdMapChannel;
 
 	@Autowired
+	@Qualifier("fourthMapChannel")
 	private MessageChannel fourthMapChannel;
 
 	@Autowired
+	@Qualifier("fifthMapChannel")
 	private MessageChannel fifthMapChannel;
 
 	@Autowired
+	@Qualifier("sixthMapChannel")
 	private MessageChannel sixthMapChannel;
 
 	@Autowired
+	@Qualifier("bulkMapChannel")
+	private MessageChannel bulkMapChannel;
+
+	@Autowired
+	@Qualifier("multiMapChannel")
 	private MessageChannel multiMapChannel;
 
 	@Autowired
+	@Qualifier("replicatedMapChannel")
 	private MessageChannel replicatedMapChannel;
 
 	@Autowired
+	@Qualifier("bulkReplicatedMapChannel")
+	private MessageChannel bulkReplicatedMapChannel;
+
+	@Autowired
+	@Qualifier("listChannel")
 	private MessageChannel listChannel;
 
 	@Autowired
+	@Qualifier("bulkListChannel")
+	private MessageChannel bulkListChannel;
+
+	@Autowired
+	@Qualifier("setChannel")
 	private MessageChannel setChannel;
 
 	@Autowired
+	@Qualifier("bulkSetChannel")
+	private MessageChannel bulkSetChannel;
+
+	@Autowired
+	@Qualifier("queueChannel")
 	private MessageChannel queueChannel;
 
 	@Autowired
-	private MessageChannel topicChannel;
+	@Qualifier("bulkQueueChannel")
+	private MessageChannel bulkQueueChannel;
 
 	@Autowired
-	private MessageChannel differentDistributedObjectsChannel;
+	@Qualifier("topicChannel")
+	private MessageChannel topicChannel;
 
 	@Resource
 	private Map<?, ?> distributedMap;
+
+	@Resource
+	private Map<?, ?> distributedBulkMap;
 
 	@Resource
 	private MultiMap<Integer, HazelcastIntegrationTestUser> multiMap;
@@ -140,65 +170,102 @@ public class HazelcastOutboundChannelAdapterTests {
 	private ReplicatedMap<Integer, HazelcastIntegrationTestUser> replicatedMap;
 
 	@Resource
+	private ReplicatedMap<Integer, HazelcastIntegrationTestUser> bulkReplicatedMap;
+
+	@Resource
 	private List<HazelcastIntegrationTestUser> distributedList;
+
+	@Resource
+	private List<HazelcastIntegrationTestUser> distributedBulkList;
 
 	@Resource
 	private Set<HazelcastIntegrationTestUser> distributedSet;
 
 	@Resource
+	private Set<HazelcastIntegrationTestUser> distributedBulkSet;
+
+	@Resource
 	private Queue<HazelcastIntegrationTestUser> distributedQueue;
+
+	@Resource
+	private Queue<HazelcastIntegrationTestUser> distributedBulkQueue;
 
 	@Resource
 	private ITopic<HazelcastIntegrationTestUser> topic;
 
 	@Autowired
 	@Qualifier("testFirstMapRequestHandlerAdvice")
-	private TestRequestHandlerAdvice testFirstMapRequestHandlerAdvice;
+	private HazelcastTestRequestHandlerAdvice testFirstMapRequestHandlerAdvice;
 
 	@Autowired
 	@Qualifier("testSecondMapRequestHandlerAdvice")
-	private TestRequestHandlerAdvice testSecondMapRequestHandlerAdvice;
+	private HazelcastTestRequestHandlerAdvice testSecondMapRequestHandlerAdvice;
 
 	@Autowired
 	@Qualifier("testThirdMapRequestHandlerAdvice")
-	private TestRequestHandlerAdvice testThirdMapRequestHandlerAdvice;
+	private HazelcastTestRequestHandlerAdvice testThirdMapRequestHandlerAdvice;
 
 	@Autowired
 	@Qualifier("testFourthMapRequestHandlerAdvice")
-	private TestRequestHandlerAdvice testFourthMapRequestHandlerAdvice;
+	private HazelcastTestRequestHandlerAdvice testFourthMapRequestHandlerAdvice;
+
+	@Autowired
+	@Qualifier("testBulkMapRequestHandlerAdvice")
+	private HazelcastTestRequestHandlerAdvice testBulkMapRequestHandlerAdvice;
 
 	@Autowired
 	@Qualifier("testMultiMapRequestHandlerAdvice")
-	private TestRequestHandlerAdvice testMultiMapRequestHandlerAdvice;
+	private HazelcastTestRequestHandlerAdvice testMultiMapRequestHandlerAdvice;
 
 	@Autowired
 	@Qualifier("testReplicatedMapRequestHandlerAdvice")
-	private TestRequestHandlerAdvice testReplicatedMapRequestHandlerAdvice;
+	private HazelcastTestRequestHandlerAdvice testReplicatedMapRequestHandlerAdvice;
+
+	@Autowired
+	@Qualifier("testBulkReplicatedMapRequestHandlerAdvice")
+	private HazelcastTestRequestHandlerAdvice testBulkReplicatedMapRequestHandlerAdvice;
 
 	@Autowired
 	@Qualifier("testListRequestHandlerAdvice")
-	private TestRequestHandlerAdvice testListRequestHandlerAdvice;
+	private HazelcastTestRequestHandlerAdvice testListRequestHandlerAdvice;
+
+	@Autowired
+	@Qualifier("testBulkListRequestHandlerAdvice")
+	private HazelcastTestRequestHandlerAdvice testBulkListRequestHandlerAdvice;
 
 	@Autowired
 	@Qualifier("testSetRequestHandlerAdvice")
-	private TestRequestHandlerAdvice testSetRequestHandlerAdvice;
+	private HazelcastTestRequestHandlerAdvice testSetRequestHandlerAdvice;
+
+	@Autowired
+	@Qualifier("testBulkSetRequestHandlerAdvice")
+	private HazelcastTestRequestHandlerAdvice testBulkSetRequestHandlerAdvice;
 
 	@Autowired
 	@Qualifier("testQueueRequestHandlerAdvice")
-	private TestRequestHandlerAdvice testQueueRequestHandlerAdvice;
+	private HazelcastTestRequestHandlerAdvice testQueueRequestHandlerAdvice;
+
+	@Autowired
+	@Qualifier("testBulkQueueRequestHandlerAdvice")
+	private HazelcastTestRequestHandlerAdvice testBulkQueueRequestHandlerAdvice;
 
 	@Autowired
 	@Qualifier("testTopicRequestHandlerAdvice")
-	private TestRequestHandlerAdvice testTopicRequestHandlerAdvice;
+	private HazelcastTestRequestHandlerAdvice testTopicRequestHandlerAdvice;
 
 	@Before
 	public void setUp() {
 		this.distributedMap.clear();
+		this.distributedBulkMap.clear();
 		this.distributedList.clear();
+		this.distributedBulkList.clear();
 		this.distributedSet.clear();
+		this.distributedBulkSet.clear();
 		this.distributedQueue.clear();
+		this.distributedBulkQueue.clear();
 		this.multiMap.clear();
 		this.replicatedMap.clear();
+		this.bulkReplicatedMap.clear();
 	}
 
 	@Test
@@ -207,6 +274,20 @@ public class HazelcastOutboundChannelAdapterTests {
 		assertTrue(this.testFirstMapRequestHandlerAdvice.executeLatch.await(10,
 				TimeUnit.SECONDS));
 		verifyMapForPayload(new TreeMap(this.distributedMap));
+	}
+
+	@Test
+	public void testBulkWriteToDistributedMap() throws InterruptedException {
+		Map<Integer, HazelcastIntegrationTestUser> userMap = new HashMap<>(DATA_COUNT);
+		for (int index = 1; index <= DATA_COUNT; index++) {
+			userMap.put(index, getTestUser(index));
+		}
+
+		this.bulkMapChannel.send(new GenericMessage<>(userMap));
+
+		assertTrue(this.testBulkMapRequestHandlerAdvice.executeLatch.await(10,
+				TimeUnit.SECONDS));
+		verifyMapForPayload(new TreeMap(this.distributedBulkMap));
 	}
 
 	@Test
@@ -256,11 +337,40 @@ public class HazelcastOutboundChannelAdapterTests {
 	}
 
 	@Test
+	public void testBulkWriteToReplicatedMap() throws InterruptedException {
+		Map<Integer, HazelcastIntegrationTestUser> userMap = new HashMap<>(DATA_COUNT);
+		for (int index = 1; index <= DATA_COUNT; index++) {
+			userMap.put(index, getTestUser(index));
+		}
+
+		this.bulkReplicatedMapChannel.send(new GenericMessage<>(userMap));
+
+		assertTrue(this.testBulkReplicatedMapRequestHandlerAdvice.executeLatch.await(10,
+				TimeUnit.SECONDS));
+		verifyMapForPayload(new TreeMap(this.bulkReplicatedMap));
+	}
+
+
+	@Test
 	public void testWriteToDistributedList() throws InterruptedException {
 		sendMessageToChannel(this.listChannel);
 		assertTrue(this.testListRequestHandlerAdvice.executeLatch.await(10,
 				TimeUnit.SECONDS));
 		verifyCollection(this.distributedList, DATA_COUNT);
+	}
+
+	@Test
+	public void testBulkWriteToDistributedList() throws InterruptedException {
+		List<HazelcastIntegrationTestUser> userList = new ArrayList<>(DATA_COUNT);
+		for (int index = 1; index <= DATA_COUNT; index++) {
+			userList.add(getTestUser(index));
+		}
+
+		this.bulkListChannel.send(new GenericMessage<>(userList));
+
+		assertTrue(this.testBulkListRequestHandlerAdvice.executeLatch.await(10,
+				TimeUnit.SECONDS));
+		verifyCollection(this.distributedBulkList, DATA_COUNT);
 	}
 
 	@Test
@@ -274,6 +384,22 @@ public class HazelcastOutboundChannelAdapterTests {
 	}
 
 	@Test
+	public void testBulkWriteToDistributedSet() throws InterruptedException {
+		Set<HazelcastIntegrationTestUser> userSet = new HashSet<>(DATA_COUNT);
+		for (int index = 1; index <= DATA_COUNT; index++) {
+			userSet.add(getTestUser(index));
+		}
+
+		this.bulkSetChannel.send(new GenericMessage<>(userSet));
+
+		assertTrue(this.testBulkSetRequestHandlerAdvice.executeLatch.await(10,
+				TimeUnit.SECONDS));
+		final List<HazelcastIntegrationTestUser> list = new ArrayList(this.distributedBulkSet);
+		Collections.sort(list);
+		verifyCollection(list, DATA_COUNT);
+	}
+
+	@Test
 	public void testWriteToDistributedQueue() throws InterruptedException {
 		sendMessageToChannel(this.queueChannel);
 		assertTrue(this.testQueueRequestHandlerAdvice.executeLatch.await(10,
@@ -282,32 +408,25 @@ public class HazelcastOutboundChannelAdapterTests {
 	}
 
 	@Test
+	public void testBulkWriteToDistributedQueue() throws InterruptedException {
+		Queue<HazelcastIntegrationTestUser> userQueue = new ArrayBlockingQueue(DATA_COUNT);
+		for (int index = 1; index <= DATA_COUNT; index++) {
+			userQueue.add(getTestUser(index));
+		}
+
+		this.bulkQueueChannel.send(new GenericMessage<>(userQueue));
+
+		assertTrue(this.testBulkQueueRequestHandlerAdvice.executeLatch.await(10,
+				TimeUnit.SECONDS));
+		verifyCollection(this.distributedBulkQueue, DATA_COUNT);
+	}
+
+	@Test
 	public void testWriteToTopic() throws InterruptedException {
 		this.topic.addMessageListener(new TestTopicMessageListener());
 		sendMessageToChannel(this.topicChannel);
 		assertTrue(this.testTopicRequestHandlerAdvice.executeLatch.await(10,
 				TimeUnit.SECONDS));
-	}
-
-	@Test
-	public void testWriteToDifferentDistributedObjects() throws InterruptedException {
-		int id = 1;
-		HazelcastIntegrationTestUser user = getTestUser(id);
-		Message<HazelcastIntegrationTestUser> message = this.messageBuilderFactory
-				.withPayload(user).setHeader(CACHE_HEADER, DISTRIBUTED_MAP).build();
-		this.differentDistributedObjectsChannel.send(message);
-		verifyHazelcastIntegrationTestUser(
-				(HazelcastIntegrationTestUser) this.distributedMap.get(id), id);
-
-		message = this.messageBuilderFactory.withPayload(user)
-				.setHeader(CACHE_HEADER, DISTRIBUTED_LIST).build();
-		this.differentDistributedObjectsChannel.send(message);
-		verifyCollection(this.distributedList, 1);
-
-		message = this.messageBuilderFactory.withPayload(user)
-				.setHeader(CACHE_HEADER, DISTRIBUTED_QUEUE).build();
-		this.differentDistributedObjectsChannel.send(message);
-		verifyCollection(this.distributedQueue, 1);
 	}
 
 	@Test(expected = MessageHandlingException.class)
@@ -403,23 +522,6 @@ public class HazelcastOutboundChannelAdapterTests {
 	private HazelcastIntegrationTestUser getTestUser(int index) {
 		return new HazelcastIntegrationTestUser(index, TEST_NAME, TEST_SURNAME, index
 				+ DEFAULT_AGE);
-	}
-
-	private static class TestRequestHandlerAdvice extends AbstractRequestHandlerAdvice {
-
-		private final CountDownLatch executeLatch = new CountDownLatch(DATA_COUNT);
-
-		@Override
-		protected Object doInvoke(ExecutionCallback callback, Object target,
-				Message<?> message) throws Exception {
-			try {
-				return callback.execute();
-			}
-			finally {
-				this.executeLatch.countDown();
-			}
-		}
-
 	}
 
 	private class TestTopicMessageListener implements MessageListener {

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/outbound/HazelcastOutboundChannelAdapterTests.java
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/outbound/HazelcastOutboundChannelAdapterTests.java
@@ -16,42 +16,49 @@
 
 package org.springframework.integration.hazelcast.outbound;
 
-import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Queue;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Resource;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.integration.handler.advice.AbstractRequestHandlerAdvice;
+import org.springframework.integration.hazelcast.HazelcastHeaders;
+import org.springframework.integration.hazelcast.HazelcastIntegrationTestUser;
+import org.springframework.integration.support.DefaultMessageBuilderFactory;
+import org.springframework.integration.support.MessageBuilderFactory;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandlingException;
-import org.springframework.messaging.PollableChannel;
-import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.hazelcast.core.ITopic;
+import com.hazelcast.core.MessageListener;
+import com.hazelcast.core.MultiMap;
+import com.hazelcast.core.ReplicatedMap;
 
 /**
  * Hazelcast Outbound Channel Adapter Test Class
@@ -63,12 +70,50 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
 @DirtiesContext
+@SuppressWarnings({ "rawtypes", "unchecked" })
 public class HazelcastOutboundChannelAdapterTests {
 
 	private static final int DATA_COUNT = 100;
 
+	private static final int DEFAULT_AGE = 5;
+
+	private static final String TEST_NAME = "Test_Name";
+
+	private static final String TEST_SURNAME = "Test_Surname";
+
+	private static final String DISTRIBUTED_MAP = "distributedMap";
+
+	private static final String DISTRIBUTED_LIST = "distributedList";
+
+	private static final String DISTRIBUTED_QUEUE = "distributedQueue";
+
+	private static final String CACHE_HEADER = "CACHE_HEADER";
+
+	private final MessageBuilderFactory messageBuilderFactory = new DefaultMessageBuilderFactory();
+
 	@Autowired
-	private MessageChannel mapChannel;
+	private MessageChannel firstMapChannel;
+
+	@Autowired
+	private MessageChannel secondMapChannel;
+
+	@Autowired
+	private MessageChannel thirdMapChannel;
+
+	@Autowired
+	private MessageChannel fourthMapChannel;
+
+	@Autowired
+	private MessageChannel fifthMapChannel;
+
+	@Autowired
+	private MessageChannel sixthMapChannel;
+
+	@Autowired
+	private MessageChannel multiMapChannel;
+
+	@Autowired
+	private MessageChannel replicatedMapChannel;
 
 	@Autowired
 	private MessageChannel listChannel;
@@ -80,158 +125,313 @@ public class HazelcastOutboundChannelAdapterTests {
 	private MessageChannel queueChannel;
 
 	@Autowired
-	private PollableChannel errorChannel;
+	private MessageChannel topicChannel;
+
+	@Autowired
+	private MessageChannel differentDistributedObjectsChannel;
 
 	@Resource
 	private Map<?, ?> distributedMap;
 
 	@Resource
-	private List<?> distributedList;
+	private MultiMap<Integer, HazelcastIntegrationTestUser> multiMap;
 
 	@Resource
-	private Set<?> distributedSet;
+	private ReplicatedMap<Integer, HazelcastIntegrationTestUser> replicatedMap;
 
 	@Resource
-	private Queue<?> distributedQueue;
+	private List<HazelcastIntegrationTestUser> distributedList;
+
+	@Resource
+	private Set<HazelcastIntegrationTestUser> distributedSet;
+
+	@Resource
+	private Queue<HazelcastIntegrationTestUser> distributedQueue;
+
+	@Resource
+	private ITopic<HazelcastIntegrationTestUser> topic;
 
 	@Autowired
-	private TestRequestHandlerAdvice testRequestHandlerAdvice;
+	@Qualifier("testFirstMapRequestHandlerAdvice")
+	private TestRequestHandlerAdvice testFirstMapRequestHandlerAdvice;
+
+	@Autowired
+	@Qualifier("testSecondMapRequestHandlerAdvice")
+	private TestRequestHandlerAdvice testSecondMapRequestHandlerAdvice;
+
+	@Autowired
+	@Qualifier("testThirdMapRequestHandlerAdvice")
+	private TestRequestHandlerAdvice testThirdMapRequestHandlerAdvice;
+
+	@Autowired
+	@Qualifier("testFourthMapRequestHandlerAdvice")
+	private TestRequestHandlerAdvice testFourthMapRequestHandlerAdvice;
+
+	@Autowired
+	@Qualifier("testMultiMapRequestHandlerAdvice")
+	private TestRequestHandlerAdvice testMultiMapRequestHandlerAdvice;
+
+	@Autowired
+	@Qualifier("testReplicatedMapRequestHandlerAdvice")
+	private TestRequestHandlerAdvice testReplicatedMapRequestHandlerAdvice;
+
+	@Autowired
+	@Qualifier("testListRequestHandlerAdvice")
+	private TestRequestHandlerAdvice testListRequestHandlerAdvice;
+
+	@Autowired
+	@Qualifier("testSetRequestHandlerAdvice")
+	private TestRequestHandlerAdvice testSetRequestHandlerAdvice;
+
+	@Autowired
+	@Qualifier("testQueueRequestHandlerAdvice")
+	private TestRequestHandlerAdvice testQueueRequestHandlerAdvice;
+
+	@Autowired
+	@Qualifier("testTopicRequestHandlerAdvice")
+	private TestRequestHandlerAdvice testTopicRequestHandlerAdvice;
 
 	@Before
 	public void setUp() {
-		distributedMap.clear();
-		distributedList.clear();
-		distributedSet.clear();
-		distributedQueue.clear();
+		this.distributedMap.clear();
+		this.distributedList.clear();
+		this.distributedSet.clear();
+		this.distributedQueue.clear();
+		this.multiMap.clear();
+		this.replicatedMap.clear();
 	}
 
 	@Test
-	public void testWriteDistributedMap() {
-		Map<Integer, String> map = createMapByEntryCount();
-		mapChannel.send(new GenericMessage<>(map));
-		verifyDistributedMap();
+	public void testWriteToDistributedMap() throws InterruptedException {
+		sendMessageToChannel(this.firstMapChannel);
+		assertTrue(this.testFirstMapRequestHandlerAdvice.executeLatch.await(10,
+				TimeUnit.SECONDS));
+		verifyMapForPayload(new TreeMap(this.distributedMap));
 	}
 
 	@Test
-	public void testWriteDistributedList() {
-		List<Integer> list = (List<Integer>) fillCollectionByEntryCount(new ArrayList<Integer>());
-		listChannel.send(new GenericMessage<>(list));
-		verifyDistributedList();
+	public void testWriteToDistributedMapWhenCacheExpressionIsSet()
+			throws InterruptedException {
+		sendMessageWithCacheHeaderToChannel(this.secondMapChannel, CACHE_HEADER,
+				DISTRIBUTED_MAP);
+		assertTrue(this.testSecondMapRequestHandlerAdvice.executeLatch.await(10,
+				TimeUnit.SECONDS));
+		verifyMapForPayload(new TreeMap(this.distributedMap));
 	}
 
 	@Test
-	public void testWriteDistributedSet() {
-		Set<Integer> set = (Set<Integer>) fillCollectionByEntryCount(new HashSet<Integer>());
-		setChannel.send(new GenericMessage<>(set));
-		verifyDistributedSet();
+	public void testWriteToDistributedMapWhenHazelcastHeaderIsSet()
+			throws InterruptedException {
+		sendMessageWithCacheHeaderToChannel(this.thirdMapChannel,
+				HazelcastHeaders.CACHE_NAME, DISTRIBUTED_MAP);
+		assertTrue(this.testThirdMapRequestHandlerAdvice.executeLatch.await(10,
+				TimeUnit.SECONDS));
+		verifyMapForPayload(new TreeMap(this.distributedMap));
 	}
 
 	@Test
-	public void testWriteDistributedQueue() throws InterruptedException {
-		Collection<Integer> queue = fillCollectionByEntryCount(new LinkedBlockingQueue<Integer>(DATA_COUNT));
-		this.queueChannel.send(new GenericMessage<>(queue));
-
-		assertTrue(this.testRequestHandlerAdvice.executeLatch.await(10, TimeUnit.SECONDS));
-
-		Assert.assertEquals(true, this.distributedQueue.size() == DATA_COUNT);
-		int index = 0;
-		for (Object o : this.distributedQueue) {
-			Assert.assertEquals(index++, o);
-		}
+	public void testWriteToDistributedMapWhenExtractPayloadIsFalse()
+			throws InterruptedException {
+		sendMessageWithCacheHeaderToChannel(this.fourthMapChannel,
+				HazelcastHeaders.CACHE_NAME, DISTRIBUTED_MAP);
+		assertTrue(this.testFourthMapRequestHandlerAdvice.executeLatch.await(10,
+				TimeUnit.SECONDS));
+		verifyMapForMessage(new TreeMap(this.distributedMap));
 	}
 
-	@Test(expected = MessageHandlingException.class)
-	public void testMapChannelWithIncorrectDataType() {
-		Set<Integer> set = new HashSet<>();
-		set.add(1);
-		mapChannel.send(new GenericMessage<>(set));
+	@Test
+	public void testWriteToMultiMap() throws InterruptedException {
+		sendMessageToChannel(this.multiMapChannel);
+		assertTrue(this.testMultiMapRequestHandlerAdvice.executeLatch.await(10,
+				TimeUnit.SECONDS));
+		verifyMultiMapForPayload(this.multiMap);
 	}
 
-	@Test(expected = MessageHandlingException.class)
-	public void testListChannelWithIncorrectDataType() {
-		Set<Integer> set = new HashSet<>();
-		set.add(1);
-		listChannel.send(new GenericMessage<>(set));
+	@Test
+	public void testWriteToReplicatedMap() throws InterruptedException {
+		sendMessageToChannel(this.replicatedMapChannel);
+		assertTrue(this.testReplicatedMapRequestHandlerAdvice.executeLatch.await(10,
+				TimeUnit.SECONDS));
+		verifyMapForPayload(new TreeMap(this.replicatedMap));
 	}
 
-	@Test(expected = MessageHandlingException.class)
-	public void testSetChannelWithIncorrectDataType() {
-		List<Integer> list = new ArrayList<>();
-		list.add(1);
-		setChannel.send(new GenericMessage<>(list));
+	@Test
+	public void testWriteToDistributedList() throws InterruptedException {
+		sendMessageToChannel(this.listChannel);
+		assertTrue(this.testListRequestHandlerAdvice.executeLatch.await(10,
+				TimeUnit.SECONDS));
+		verifyCollection(this.distributedList, DATA_COUNT);
 	}
 
-	public void testQueueChannelWithIncorrectDataType() {
-		Set<Integer> set = new HashSet<>();
-		set.add(1);
-		this.queueChannel.send(new GenericMessage<>(set));
-		Message<?> receive = this.errorChannel.receive(10000);
-		assertNotNull(receive);
-		assertThat(receive, instanceOf(ErrorMessage.class));
-		assertThat(receive.getPayload(), instanceOf(MessageHandlingException.class));
-
-	}
-
-	private Map<Integer, String> createMapByEntryCount() {
-		Map<Integer, String> map = new HashMap<>();
-		StringBuilder strBuilder = new StringBuilder();
-		for (int index = 0; index < DATA_COUNT; index++) {
-			String value = strBuilder.append("Value_").append(index).toString();
-			map.put(index, value);
-			strBuilder.delete(0, strBuilder.length());
-		}
-
-		return map;
-	}
-
-	private void verifyDistributedMap() {
-		Assert.assertEquals(true, distributedMap.size() == DATA_COUNT);
-
-		StringBuilder strBuilder = new StringBuilder();
-		for (int index = 0; index < DATA_COUNT; index++) {
-			String value = strBuilder.append("Value_").append(index).toString();
-			Assert.assertEquals(value, distributedMap.get(index));
-			strBuilder.delete(0, strBuilder.length());
-		}
-	}
-
-	private Collection<Integer> fillCollectionByEntryCount(Collection<Integer> coll) {
-		for (int index = 0; index < DATA_COUNT; index++) {
-			coll.add(index);
-		}
-
-		return coll;
-	}
-
-	private void verifyDistributedList() {
-		Assert.assertEquals(true, distributedList.size() == DATA_COUNT);
-		for (int index = 0; index < DATA_COUNT; index++) {
-			Assert.assertEquals(index, distributedList.get(index));
-		}
-	}
-
-	@SuppressWarnings({"unchecked", "rawtypes"})
-	private void verifyDistributedSet() {
-		Assert.assertEquals(true, distributedSet.size() == DATA_COUNT);
-		List list = new ArrayList(distributedSet);
+	@Test
+	public void testWriteToDistributedSet() throws InterruptedException {
+		sendMessageToChannel(this.setChannel);
+		assertTrue(this.testSetRequestHandlerAdvice.executeLatch.await(10,
+				TimeUnit.SECONDS));
+		final List<HazelcastIntegrationTestUser> list = new ArrayList(this.distributedSet);
 		Collections.sort(list);
-		for (int index = 0; index < DATA_COUNT; index++) {
-			Assert.assertEquals(index, list.get(index));
+		verifyCollection(list, DATA_COUNT);
+	}
+
+	@Test
+	public void testWriteToDistributedQueue() throws InterruptedException {
+		sendMessageToChannel(this.queueChannel);
+		assertTrue(this.testQueueRequestHandlerAdvice.executeLatch.await(10,
+				TimeUnit.SECONDS));
+		verifyCollection(this.distributedQueue, DATA_COUNT);
+	}
+
+	@Test
+	public void testWriteToTopic() throws InterruptedException {
+		this.topic.addMessageListener(new TestTopicMessageListener());
+		sendMessageToChannel(this.topicChannel);
+		assertTrue(this.testTopicRequestHandlerAdvice.executeLatch.await(10,
+				TimeUnit.SECONDS));
+	}
+
+	@Test
+	public void testWriteToDifferentDistributedObjects() throws InterruptedException {
+		int id = 1;
+		HazelcastIntegrationTestUser user = getTestUser(id);
+		Message<HazelcastIntegrationTestUser> message = this.messageBuilderFactory
+				.withPayload(user).setHeader(CACHE_HEADER, DISTRIBUTED_MAP).build();
+		this.differentDistributedObjectsChannel.send(message);
+		verifyHazelcastIntegrationTestUser(
+				(HazelcastIntegrationTestUser) this.distributedMap.get(id), id);
+
+		message = this.messageBuilderFactory.withPayload(user)
+				.setHeader(CACHE_HEADER, DISTRIBUTED_LIST).build();
+		this.differentDistributedObjectsChannel.send(message);
+		verifyCollection(this.distributedList, 1);
+
+		message = this.messageBuilderFactory.withPayload(user)
+				.setHeader(CACHE_HEADER, DISTRIBUTED_QUEUE).build();
+		this.differentDistributedObjectsChannel.send(message);
+		verifyCollection(this.distributedQueue, 1);
+	}
+
+	@Test(expected = MessageHandlingException.class)
+	public void testWriteToDistributedMapWhenCacheIsNotSet() {
+		this.fifthMapChannel.send(new GenericMessage<>(getTestUser(1)));
+	}
+
+	@Test(expected = MessageHandlingException.class)
+	public void testWriteToDistributedMapWhenKeyExpressionIsNotSet() {
+		Message<HazelcastIntegrationTestUser> message = this.messageBuilderFactory
+				.withPayload(getTestUser(1))
+				.setHeader(HazelcastHeaders.CACHE_NAME, DISTRIBUTED_MAP).build();
+		this.sixthMapChannel.send(message);
+	}
+
+	private void sendMessageToChannel(final MessageChannel channel) {
+		for (int index = 1; index <= DATA_COUNT; index++) {
+			channel.send(new GenericMessage<>(getTestUser(index)));
 		}
 	}
 
-	public static class TestRequestHandlerAdvice extends AbstractRequestHandlerAdvice {
+	private void sendMessageWithCacheHeaderToChannel(final MessageChannel channel,
+			final String headerName, final String distributedObjectName) {
+		for (int index = 1; index <= DATA_COUNT; index++) {
+			Message<HazelcastIntegrationTestUser> message = this.messageBuilderFactory
+					.withPayload(getTestUser(index))
+					.setHeader(headerName, distributedObjectName).build();
+			channel.send(message);
+		}
+	}
 
-		public final CountDownLatch executeLatch = new CountDownLatch(1);
+	private void verifyMapForPayload(final Map<Integer, HazelcastIntegrationTestUser> map) {
+		int index = 1;
+		assertNotNull(map);
+		assertEquals(true, map.size() == DATA_COUNT);
+		for (Entry<Integer, HazelcastIntegrationTestUser> entry : map.entrySet()) {
+			assertNotNull(entry);
+			assertEquals(index, entry.getKey().intValue());
+			verifyHazelcastIntegrationTestUser(entry.getValue(), index);
+			index++;
+		}
+	}
+
+	private void verifyMultiMapForPayload(
+			final MultiMap<Integer, HazelcastIntegrationTestUser> multiMap) {
+		int index = 1;
+		assertNotNull(multiMap);
+		assertEquals(true, multiMap.size() == DATA_COUNT);
+		SortedSet<Integer> keys = new TreeSet<>(multiMap.keySet());
+		for (Integer key : keys) {
+			assertNotNull(key);
+			assertEquals(index, key.intValue());
+			HazelcastIntegrationTestUser user = multiMap.get(key).iterator().next();
+			verifyHazelcastIntegrationTestUser(user, index);
+			index++;
+		}
+	}
+
+	private void verifyMapForMessage(
+			final Map<Integer, Message<HazelcastIntegrationTestUser>> map) {
+		int index = 1;
+		assertNotNull(map);
+		assertEquals(true, map.size() == DATA_COUNT);
+		for (Entry<Integer, Message<HazelcastIntegrationTestUser>> entry : map.entrySet()) {
+			assertNotNull(entry);
+			assertEquals(index, entry.getKey().intValue());
+			assertTrue(entry.getValue().getHeaders().size() > 0);
+			verifyHazelcastIntegrationTestUser(entry.getValue().getPayload(), index);
+			index++;
+		}
+	}
+
+	private void verifyCollection(final Collection<HazelcastIntegrationTestUser> coll,
+			final int dataCount) {
+		int index = 1;
+		assertNotNull(coll);
+		assertEquals(true, coll.size() == dataCount);
+		for (HazelcastIntegrationTestUser user : coll) {
+			verifyHazelcastIntegrationTestUser(user, index);
+			index++;
+		}
+	}
+
+	private void verifyHazelcastIntegrationTestUser(HazelcastIntegrationTestUser user,
+			int index) {
+		assertNotNull(user);
+		assertEquals(index, user.getId());
+		assertEquals(TEST_NAME, user.getName());
+		assertEquals(TEST_SURNAME, user.getSurname());
+		assertEquals(index + DEFAULT_AGE, user.getAge());
+	}
+
+	private HazelcastIntegrationTestUser getTestUser(int index) {
+		return new HazelcastIntegrationTestUser(index, TEST_NAME, TEST_SURNAME, index
+				+ DEFAULT_AGE);
+	}
+
+	private static class TestRequestHandlerAdvice extends AbstractRequestHandlerAdvice {
+
+		private final CountDownLatch executeLatch = new CountDownLatch(DATA_COUNT);
 
 		@Override
-		protected Object doInvoke(ExecutionCallback callback, Object target, Message<?> message) throws Exception {
+		protected Object doInvoke(ExecutionCallback callback, Object target,
+				Message<?> message) throws Exception {
 			try {
 				return callback.execute();
 			}
 			finally {
 				this.executeLatch.countDown();
 			}
+		}
+
+	}
+
+	private class TestTopicMessageListener implements MessageListener {
+
+		private int index = 1;
+
+		@Override
+		public void onMessage(com.hazelcast.core.Message message) {
+			HazelcastIntegrationTestUser user = (HazelcastIntegrationTestUser) message
+					.getMessageObject();
+			verifyHazelcastIntegrationTestUser(user, index);
+			index++;
 		}
 
 	}


### PR DESCRIPTION
**JIRA :** https://jira.spring.io/browse/INTEXT-149

**HazelcastCacheWritingMessageHandler** has been refactored in order to support single entry and ITopic, MultiMap and ReplicatedMap.

Also SI version has been upgraded to v4.1.3.