### PR TITLE
GH-172: Do not require local HZ instances

### DIFF
--- a/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/config/HazelcastIntegrationConfigurationInitializer.java
+++ b/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/config/HazelcastIntegrationConfigurationInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,18 +27,17 @@ import org.springframework.integration.hazelcast.HazelcastLocalInstanceRegistrar
  * The Hazelcast Integration infrastructure {@code beanFactory} initializer.
  *
  * @author Eren Avsarogullari
+ * @author Artem Bilan
+ *
  * @since 1.0.0
  */
 public class HazelcastIntegrationConfigurationInitializer implements IntegrationConfigurationInitializer {
 
-	private static final String HAZELCAST_LOCAL_INSTANCE_REGISTRAR_BEAN_NAME =
-			HazelcastLocalInstanceRegistrar.class.getName();
-
 	@Override
 	public void initialize(ConfigurableListableBeanFactory beanFactory) throws BeansException {
 		BeanDefinitionRegistry beanDefinitionRegistry = (BeanDefinitionRegistry) beanFactory;
-		if (!beanDefinitionRegistry.containsBeanDefinition(HAZELCAST_LOCAL_INSTANCE_REGISTRAR_BEAN_NAME)) {
-			beanDefinitionRegistry.registerBeanDefinition(HAZELCAST_LOCAL_INSTANCE_REGISTRAR_BEAN_NAME,
+		if (!beanDefinitionRegistry.containsBeanDefinition(HazelcastLocalInstanceRegistrar.BEAN_NAME)) {
+			beanDefinitionRegistry.registerBeanDefinition(HazelcastLocalInstanceRegistrar.BEAN_NAME,
 					new RootBeanDefinition(HazelcastLocalInstanceRegistrar.class));
 		}
 	}

--- a/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/inbound/AbstractHazelcastMessageProducer.java
+++ b/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/inbound/AbstractHazelcastMessageProducer.java
@@ -48,6 +48,7 @@ import com.hazelcast.core.MultiMap;
  *
  * @author Eren Avsarogullari
  * @author Artem Bilan
+ *
  * @since 1.0.0
  */
 public abstract class AbstractHazelcastMessageProducer extends MessageProducerSupport {
@@ -116,10 +117,11 @@ public abstract class AbstractHazelcastMessageProducer extends MessageProducerSu
 		private boolean isEventAcceptable(final InetSocketAddress socketAddress) {
 			final Set<HazelcastInstance> hazelcastInstanceSet = Hazelcast.getAllHazelcastInstances();
 			final Set<SocketAddress> localSocketAddressesSet = getLocalSocketAddresses(hazelcastInstanceSet);
-			return (!localSocketAddressesSet.isEmpty())
-					&& (localSocketAddressesSet.contains(socketAddress) ||
-					isEventComingFromNonRegisteredHazelcastInstance(hazelcastInstanceSet.iterator().next(),
-							localSocketAddressesSet, socketAddress));
+			return localSocketAddressesSet.isEmpty() ||
+					(!localSocketAddressesSet.isEmpty()
+							&& (localSocketAddressesSet.contains(socketAddress) ||
+							isEventComingFromNonRegisteredHazelcastInstance(hazelcastInstanceSet.iterator().next(),
+									localSocketAddressesSet, socketAddress)));
 
 		}
 

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/config/HazelcastIntegrationInboundTestConfiguration.java
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/config/HazelcastIntegrationInboundTestConfiguration.java
@@ -24,6 +24,7 @@ import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.hazelcast.DistributedSQLIterationType;
 import org.springframework.integration.hazelcast.HazelcastIntegrationTestUser;
+import org.springframework.integration.hazelcast.HazelcastLocalInstanceRegistrar;
 import org.springframework.integration.hazelcast.inbound.HazelcastClusterMonitorMessageProducer;
 import org.springframework.integration.hazelcast.inbound.HazelcastContinuousQueryMessageProducer;
 import org.springframework.integration.hazelcast.inbound.HazelcastDistributedSQLMessageSource;
@@ -213,6 +214,11 @@ public class HazelcastIntegrationInboundTestConfiguration {
 	@Bean
 	public HazelcastInstance testHazelcastInstance() {
 		return Hazelcast.newHazelcastInstance();
+	}
+
+	@Bean(HazelcastLocalInstanceRegistrar.BEAN_NAME)
+	public HazelcastLocalInstanceRegistrar hazelcastLocalInstanceRegistrar() {
+		return new HazelcastLocalInstanceRegistrar(testHazelcastInstance());
 	}
 
 	@Bean


### PR DESCRIPTION
Fixes spring-projects/spring-integration-extensions#172

Since we can have an application based on the `HazelcastClient`, we don't need to require `Hazelcast.getAllHazelcastInstances()` be presented.

* Rework `HazelcastLocalInstanceRegistrar` to be able to accept external `HazelcastInstance` for `MultiMap` and `MembershipListener` registration
* If there is on local `Hazelcast.getAllHazelcastInstances()` just log a warn that we can't register `MembershipListener`
* Allow for `AbstractHazelcastMessageProducer` to accept events in the `CacheListeningPolicyType.SINGLE` mode when there is no local `Hazelcast.getAllHazelcastInstances()`