### PR TITLE
Use FILENAME as zip file name if specified

### DIFF
--- a/spring-integration-zip/src/main/java/org/springframework/integration/zip/transformer/ZipTransformer.java
+++ b/spring-integration-zip/src/main/java/org/springframework/integration/zip/transformer/ZipTransformer.java
@@ -113,7 +113,7 @@ public class ZipTransformer extends AbstractZipTransformer {
 		}
 
 		if (message.getHeaders().containsKey(FileHeaders.FILENAME)) {
-			zipFileName = baseFileName;
+			zipFileName = (String) message.getHeaders().get(FileHeaders.FILENAME);
 		}
 		else {
 			zipFileName = baseFileName + ZIP_EXTENSION;


### PR DESCRIPTION
If FILENAME is present at headers we must use this value as the name of the file without conversion