### PR TITLE
GH-193: Fix URL parsing in the `SmbConfig`

### DIFF
--- a/spring-integration-smb/src/test/java/org/springframework/integration/smb/SmbMessageHistoryTests-context.xml
+++ b/spring-integration-smb/src/test/java/org/springframework/integration/smb/SmbMessageHistoryTests-context.xml
@@ -3,10 +3,8 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-smb="http://www.springframework.org/schema/integration/smb"
-	xmlns:context="http://www.springframework.org/schema/context"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration  http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
 		http://www.springframework.org/schema/integration/smb http://www.springframework.org/schema/integration/smb/spring-integration-smb.xsd">
 
 	<int:message-history/>
@@ -15,8 +13,8 @@
 		<property name="host"        value="localhost"/>
 		<property name="port"        value="0"/>
 		<property name="domain"      value=""/>
-		<property name="username"    value="sambaguest"/>
-		<property name="password"    value="sambaguest"/>
+		<property name="username"    value="sambagu@est"/>
+		<property name="password"    value="sambag%uest"/>
 		<property name="shareAndDir" value="smb-share/"/>
 		<property name="replaceFile" value="true"/>
 	</bean>

--- a/spring-integration-smb/src/test/java/org/springframework/integration/smb/SmbMessageHistoryTests.java
+++ b/spring-integration-smb/src/test/java/org/springframework/integration/smb/SmbMessageHistoryTests.java
@@ -18,22 +18,38 @@ package org.springframework.integration.smb;
 
 import static org.junit.Assert.assertEquals;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+
 import org.junit.Test;
 
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.integration.endpoint.SourcePollingChannelAdapter;
+import org.springframework.integration.smb.session.SmbSessionFactory;
 
 /**
  * @author Markus Spann
  * @author Prafull Kumar Soni
+ * @author Artem Bilan
  *
  */
 public class SmbMessageHistoryTests extends AbstractBaseTests {
 
 	@Test
-	public void testMessageHistory() {
-		SourcePollingChannelAdapter adapter = getApplicationContext()
+	public void testMessageHistory() throws URISyntaxException {
+		ClassPathXmlApplicationContext applicationContext = getApplicationContext();
+		SourcePollingChannelAdapter adapter = applicationContext
 				.getBean("smbInboundChannelAdapter", SourcePollingChannelAdapter.class);
 		assertEquals("smbInboundChannelAdapter", adapter.getComponentName());
 		assertEquals("smb:inbound-channel-adapter", adapter.getComponentType());
+
+		SmbSessionFactory smbSessionFactory = applicationContext.getBean(SmbSessionFactory.class);
+
+		String url = smbSessionFactory.getUrl();
+		URI uri = new URI(url);
+		assertEquals("sambagu%40est:sambag%25uest", uri.getRawUserInfo());
+		assertEquals("sambagu@est:sambag%uest", uri.getUserInfo());
+
+		applicationContext.close();
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration-extensions/issues/193

The `URLEncoder` encodes the credentials unconditionally
(including colon) making such a Basic Authentication useless

* Change the logic to build the full `URI` from the components and call
its `toASCIIString()` for the proper encoding