### PR TITLE
URL Cleanup

### DIFF
--- a/samples/aws-s3/pom.xml
+++ b/samples/aws-s3/pom.xml
@@ -8,7 +8,7 @@
 	<packaging>jar</packaging>
 
 	<name>aws-s3</name>
-	<url>http://www.springsource.org/spring-integration</url>
+	<url>https://www.springsource.org/spring-integration</url>
 
 	<prerequisites>
 		<maven>2.2.1</maven>

--- a/samples/smb/pom.xml
+++ b/samples/smb/pom.xml
@@ -8,7 +8,7 @@
 	<packaging>jar</packaging>
 
 	<name>smb</name>
-	<url>http://www.springsource.org/spring-integration</url>
+	<url>https://www.springsource.org/spring-integration</url>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/samples/splunk/build.gradle
+++ b/samples/splunk/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'application'
 
 repositories {
 	mavenLocal()
-	maven { url "http://repo.springsource.org/libs-snapshot" }
+	maven { url "https://repo.springsource.org/libs-snapshot" }
 }
 
 dependencies {

--- a/samples/voldemort/pom.xml
+++ b/samples/voldemort/pom.xml
@@ -8,7 +8,7 @@
 	<packaging>jar</packaging>
 
 	<name>voldemort-sample</name>
-	<url>http://www.springsource.org/spring-integration</url>
+	<url>https://www.springsource.org/spring-integration</url>
 
 	<prerequisites>
 		<maven>2.2.1</maven>

--- a/samples/xquery/pom.xml
+++ b/samples/xquery/pom.xml
@@ -8,7 +8,7 @@
 	<packaging>jar</packaging>
 
 	<name>Samples (Basic) - XQuery Sample</name>
-	<url>http://www.springsource.org/spring-integration</url>
+	<url>https://www.springsource.org/spring-integration</url>
 
 	<prerequisites>
 		<maven>2.2.1</maven>

--- a/samples/zip/pom.xml
+++ b/samples/zip/pom.xml
@@ -8,7 +8,7 @@
 	<packaging>jar</packaging>
 
 	<name>zip-sample</name>
-	<url>http://projects.spring.io/spring-integration/</url>
+	<url>https://projects.spring.io/spring-integration/</url>
 
 	<prerequisites>
 		<maven>2.2.1</maven>

--- a/spring-integration-cassandra/build.gradle
+++ b/spring-integration-cassandra/build.gradle
@@ -22,10 +22,10 @@ group = 'org.springframework.integration'
 
 repositories {
     if (version.endsWith('BUILD-SNAPSHOT')) {
-        maven { url 'http://repo.spring.io/libs-snapshot' }
+        maven { url 'https://repo.spring.io/libs-snapshot' }
     }
-    maven { url 'http://repo.spring.io/libs-milestone' }
-//	maven { url 'http://repo.spring.io/libs-staging-local' }
+    maven { url 'https://repo.spring.io/libs-milestone' }
+//	maven { url 'https://repo.spring.io/libs-staging-local' }
 }
 
 ext {

--- a/spring-integration-cassandra/publish-maven.gradle
+++ b/spring-integration-cassandra/publish-maven.gradle
@@ -34,12 +34,12 @@ def customizePom(pom, gradleProject) {
 			url = linkHomepage
 			organization {
 				name = 'SpringIO'
-				url = 'http://spring.io'
+				url = 'https://spring.io'
 			}
 			licenses {
 				license {
 					name 'The Apache Software License, Version 2.0'
-					url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+					url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
 					distribution 'repo'
 				}
 			}

--- a/spring-integration-etcd/build.gradle
+++ b/spring-integration-etcd/build.gradle
@@ -13,9 +13,9 @@ group = 'org.springframework.integration'
 
 repositories {
 	if (version.endsWith('BUILD-SNAPSHOT')) {
-		maven { url 'http://repo.spring.io/libs-snapshot' }
+		maven { url 'https://repo.spring.io/libs-snapshot' }
 	}
-	maven { url 'http://repo.spring.io/libs-milestone' }
+	maven { url 'https://repo.spring.io/libs-milestone' }
 }
 
 sourceCompatibility = targetCompatibility = 1.8

--- a/spring-integration-etcd/publish-maven.gradle
+++ b/spring-integration-etcd/publish-maven.gradle
@@ -34,12 +34,12 @@ def customizePom(pom, gradleProject) {
 			url = linkHomepage
 			organization {
 				name = 'SpringIO'
-				url = 'http://spring.io'
+				url = 'https://spring.io'
 			}
 			licenses {
 				license {
 					name 'The Apache Software License, Version 2.0'
-					url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+					url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
 					distribution 'repo'
 				}
 			}

--- a/spring-integration-hazelcast/build.gradle
+++ b/spring-integration-hazelcast/build.gradle
@@ -25,9 +25,9 @@ group = 'org.springframework.integration'
 
 repositories {
 	if (version.endsWith('BUILD-SNAPSHOT') || project.hasProperty('platformVersion')) {
-		maven { url 'http://repo.spring.io/libs-snapshot' }
+		maven { url 'https://repo.spring.io/libs-snapshot' }
 	}
-	maven { url 'http://repo.spring.io/libs-milestone' }
+	maven { url 'https://repo.spring.io/libs-milestone' }
 }
 
 if (project.hasProperty('platformVersion')) {

--- a/spring-integration-hazelcast/publish-maven.gradle
+++ b/spring-integration-hazelcast/publish-maven.gradle
@@ -34,12 +34,12 @@ def customizePom(pom, gradleProject) {
 			url = linkHomepage
 			organization {
 				name = 'SpringIO'
-				url = 'http://spring.io'
+				url = 'https://spring.io'
 			}
 			licenses {
 				license {
 					name 'The Apache Software License, Version 2.0'
-					url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+					url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
 					distribution 'repo'
 				}
 			}

--- a/spring-integration-ip-extensions/build.gradle
+++ b/spring-integration-ip-extensions/build.gradle
@@ -17,8 +17,8 @@ apply plugin: 'idea'
 group = 'org.springintegration.ip.extensions'
 
 repositories {
-	maven { url 'http://repo.springsource.org/libs-milestone' }
-	maven { url 'http://repo.springsource.org/plugins-release' } // for bundlor
+	maven { url 'https://repo.springsource.org/libs-milestone' }
+	maven { url 'https://repo.springsource.org/plugins-release' } // for bundlor
 }
 
 sourceCompatibility=1.6
@@ -57,8 +57,8 @@ sourceSets {
 	}
 }
 
-// See http://www.gradle.org/docs/current/userguide/dependency_management.html#sub:configurations
-// and http://www.gradle.org/docs/current/dsl/org.gradle.api.artifacts.ConfigurationContainer.html
+// See https://www.gradle.org/docs/current/userguide/dependency_management.html#sub:configurations
+// and https://www.gradle.org/docs/current/dsl/org.gradle.api.artifacts.ConfigurationContainer.html
 configurations {
 	jacoco //Configuration Group used by Sonar to provide Code Coverage using JaCoCo
 }

--- a/spring-integration-ip-extensions/publish-maven.gradle
+++ b/spring-integration-ip-extensions/publish-maven.gradle
@@ -34,12 +34,12 @@ def customizePom(pom, gradleProject) {
 			url = 'https://github.com/SpringSource/spring-integration'
 			organization {
 				name = 'SpringSource'
-				url = 'http://springsource.org'
+				url = 'https://spring.io'
 			}
 			licenses {
 				license {
 					name 'The Apache Software License, Version 2.0'
-					url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+					url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
 					distribution 'repo'
 				}
 			}

--- a/spring-integration-jgroups/build.gradle
+++ b/spring-integration-jgroups/build.gradle
@@ -15,15 +15,15 @@ group = 'org.springframework.integration'
 
 repositories {
 	mavenCentral()
-	maven { url 'http://repo.springsource.org/libs-milestone' }
-	maven { url 'http://repo.springsource.org/plugins-release' }
+	maven { url 'https://repo.springsource.org/libs-milestone' }
+	maven { url 'https://repo.springsource.org/plugins-release' }
 }
 
 sourceCompatibility=1.6
 targetCompatibility=1.6
 
-// See http://www.gradle.org/docs/current/userguide/dependency_management.html#sub:configurations
-// and http://www.gradle.org/docs/current/dsl/org.gradle.api.artifacts.ConfigurationContainer.html
+// See https://www.gradle.org/docs/current/userguide/dependency_management.html#sub:configurations
+// and https://www.gradle.org/docs/current/dsl/org.gradle.api.artifacts.ConfigurationContainer.html
 configurations {
 	jacoco //Configuration Group used by Sonar to provide Code Coverage using JaCoCo
 }

--- a/spring-integration-jgroups/publish-maven.gradle
+++ b/spring-integration-jgroups/publish-maven.gradle
@@ -34,12 +34,12 @@ def customizePom(pom, gradleProject) {
 			url = 'https://github.com/SpringSource/spring-integration-extensions'
 			organization {
 				name = 'SpringSource'
-				url = 'http://springsource.org'
+				url = 'https://spring.io'
 			}
 			licenses {
 				license {
 					name 'The Apache Software License, Version 2.0'
-					url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+					url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
 					distribution 'repo'
 				}
 			}

--- a/spring-integration-jt400/build.gradle
+++ b/spring-integration-jt400/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'idea'
 group = 'org.springframework.integration'
 
 repositories {
-	maven { url 'http://repo.spring.io/libs-milestone' }
+	maven { url 'https://repo.spring.io/libs-milestone' }
 }
 
 sourceCompatibility = targetCompatibility = 1.7
@@ -217,5 +217,5 @@ task dist(dependsOn: assemble) {
 task wrapper(type: Wrapper) {
 	description = 'Generates gradlew[.bat] scripts'
 	gradleVersion = '2.3'
-	distributionUrl = "http://services.gradle.org/distributions/gradle-${gradleVersion}-all.zip"
+	distributionUrl = "https://services.gradle.org/distributions/gradle-${gradleVersion}-all.zip"
 }

--- a/spring-integration-jt400/publish-maven.gradle
+++ b/spring-integration-jt400/publish-maven.gradle
@@ -34,12 +34,12 @@ def customizePom(pom, gradleProject) {
 			url = linkHomepage
 			organization {
 				name = 'SpringIO'
-				url = 'http://spring.io'
+				url = 'https://spring.io'
 			}
 			licenses {
 				license {
 					name 'The Apache Software License, Version 2.0'
-					url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+					url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
 					distribution 'repo'
 				}
 			}

--- a/spring-integration-print/build.gradle
+++ b/spring-integration-print/build.gradle
@@ -14,8 +14,8 @@ apply plugin: 'idea'
 group = 'org.springframework.integration'
 
 repositories {
-	maven { url 'http://repo.springsource.org/libs-milestone' }
-	maven { url 'http://repo.springsource.org/plugins-release' }
+	maven { url 'https://repo.springsource.org/libs-milestone' }
+	maven { url 'https://repo.springsource.org/plugins-release' }
 }
 
 sourceCompatibility=1.6
@@ -51,8 +51,8 @@ sourceSets {
 	}
 }
 
-// See http://www.gradle.org/docs/current/userguide/dependency_management.html#sub:configurations
-// and http://www.gradle.org/docs/current/dsl/org.gradle.api.artifacts.ConfigurationContainer.html
+// See https://www.gradle.org/docs/current/userguide/dependency_management.html#sub:configurations
+// and https://www.gradle.org/docs/current/dsl/org.gradle.api.artifacts.ConfigurationContainer.html
 configurations {
 	jacoco //Configuration Group used by Sonar to provide Code Coverage using JaCoCo
 }

--- a/spring-integration-print/publish-maven.gradle
+++ b/spring-integration-print/publish-maven.gradle
@@ -34,12 +34,12 @@ def customizePom(pom, gradleProject) {
 			url = 'https://github.com/SpringSource/spring-integration'
 			organization {
 				name = 'SpringSource'
-				url = 'http://springsource.org'
+				url = 'https://spring.io'
 			}
 			licenses {
 				license {
 					name 'The Apache Software License, Version 2.0'
-					url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+					url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
 					distribution 'repo'
 				}
 			}

--- a/spring-integration-smb/build.gradle
+++ b/spring-integration-smb/build.gradle
@@ -26,9 +26,9 @@ group = 'org.springframework.integration'
 
 repositories {
 	if (version.endsWith('BUILD-SNAPSHOT') || project.hasProperty('platformVersion')) {
-		maven { url 'http://repo.spring.io/libs-snapshot' }
+		maven { url 'https://repo.spring.io/libs-snapshot' }
 	}
-	maven { url 'http://repo.spring.io/libs-milestone' }
+	maven { url 'https://repo.spring.io/libs-milestone' }
 }
 
 if (project.hasProperty('platformVersion')) {

--- a/spring-integration-smb/publish-maven.gradle
+++ b/spring-integration-smb/publish-maven.gradle
@@ -34,12 +34,12 @@ def customizePom(pom, gradleProject) {
 			url = linkHomepage
 			organization {
 				name = 'SpringIO'
-				url = 'http://spring.io'
+				url = 'https://spring.io'
 			}
 			licenses {
 				license {
 					name 'The Apache Software License, Version 2.0'
-					url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+					url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
 					distribution 'repo'
 				}
 			}

--- a/spring-integration-smpp/build.gradle
+++ b/spring-integration-smpp/build.gradle
@@ -17,7 +17,7 @@ apply plugin: 'idea'
 group = 'org.springframework.integration'
 
 repositories {
-	maven { url 'http://repo.spring.io/libs-milestone' }
+	maven { url 'https://repo.spring.io/libs-milestone' }
 }
 
 sourceCompatibility = 1.6
@@ -45,8 +45,8 @@ eclipse.project.natures += 'org.springframework.ide.eclipse.core.springnature'
 
 sourceSets.test.resources.srcDirs = ['src/test/resources', 'src/test/java']
 
-// See http://www.gradle.org/docs/current/userguide/dependency_management.html#sub:configurations
-// and http://www.gradle.org/docs/current/dsl/org.gradle.api.artifacts.ConfigurationContainer.html
+// See https://www.gradle.org/docs/current/userguide/dependency_management.html#sub:configurations
+// and https://www.gradle.org/docs/current/dsl/org.gradle.api.artifacts.ConfigurationContainer.html
 configurations {
 	jacoco //Configuration Group used by Sonar to provide Code Coverage using JaCoCo
 	all*.exclude group: 'commons-logging', module: 'commons-logging'
@@ -237,5 +237,5 @@ task dist(dependsOn: assemble) {
 task wrapper(type: Wrapper) {
 	description = 'Generates gradlew[.bat] scripts'
 	gradleVersion = '1.12'
-	distributionUrl = "http://services.gradle.org/distributions/gradle-${gradleVersion}-all.zip"
+	distributionUrl = "https://services.gradle.org/distributions/gradle-${gradleVersion}-all.zip"
 }

--- a/spring-integration-smpp/publish-maven.gradle
+++ b/spring-integration-smpp/publish-maven.gradle
@@ -34,12 +34,12 @@ def customizePom(pom, gradleProject) {
 			url = linkHomepage
 			organization {
 				name = 'SpringIO'
-				url = 'http://spring.io'
+				url = 'https://spring.io'
 			}
 			licenses {
 				license {
 					name 'The Apache Software License, Version 2.0'
-					url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+					url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
 					distribution 'repo'
 				}
 			}

--- a/spring-integration-social-twitter/build.gradle
+++ b/spring-integration-social-twitter/build.gradle
@@ -14,11 +14,11 @@ apply from: "${rootProject.projectDir}/publish-maven.gradle"
 group = 'org.springframework.integration'
 
 repositories {
-	maven { url 'http://repo.spring.io/libs-staging-local' }
+	maven { url 'https://repo.spring.io/libs-staging-local' }
 	if (version.endsWith('BUILD-SNAPSHOT')) {
-		maven { url 'http://repo.spring.io/libs-snapshot' }
+		maven { url 'https://repo.spring.io/libs-snapshot' }
 	}
-	maven { url 'http://repo.spring.io/libs-milestone' }
+	maven { url 'https://repo.spring.io/libs-milestone' }
 }
 
 compileJava {

--- a/spring-integration-social-twitter/publish-maven.gradle
+++ b/spring-integration-social-twitter/publish-maven.gradle
@@ -34,12 +34,12 @@ def customizePom(pom, gradleProject) {
 			url = linkHomepage
 			organization {
 				name = 'SpringIO'
-				url = 'http://spring.io'
+				url = 'https://spring.io'
 			}
 			licenses {
 				license {
 					name 'The Apache Software License, Version 2.0'
-					url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+					url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
 					distribution 'repo'
 				}
 			}

--- a/spring-integration-voldemort/build.gradle
+++ b/spring-integration-voldemort/build.gradle
@@ -17,8 +17,8 @@ apply plugin: 'idea'
 group = 'org.springframework.integration'
 
 repositories {
-	maven { url 'http://repo.springsource.org/libs-milestone' }
-	maven { url 'http://repo.springsource.org/plugins-release' }
+	maven { url 'https://repo.springsource.org/libs-milestone' }
+	maven { url 'https://repo.springsource.org/plugins-release' }
 }
 
 sourceCompatibility=1.6
@@ -57,8 +57,8 @@ sourceSets {
 	}
 }
 
-// See http://www.gradle.org/docs/current/userguide/dependency_management.html#sub:configurations
-// and http://www.gradle.org/docs/current/dsl/org.gradle.api.artifacts.ConfigurationContainer.html
+// See https://www.gradle.org/docs/current/userguide/dependency_management.html#sub:configurations
+// and https://www.gradle.org/docs/current/dsl/org.gradle.api.artifacts.ConfigurationContainer.html
 configurations {
 	jacoco //Configuration Group used by Sonar to provide Code Coverage using JaCoCo
 }
@@ -82,7 +82,7 @@ ext.xLintArg = '-Xlint:all'
 test {
 	// suppress all console output during testing unless running `gradle -i`
 	logging.captureStandardOutput(LogLevel.INFO)
-	// JVM settings from http://www.project-voldemort.com/voldemort/configuration.html
+	// JVM settings from https://www.project-voldemort.com/voldemort/configuration.html
 	jvmArgs "-XX:+UseConcMarkSweepGC", "-XX:+UseParNewGC", "-javaagent:${configurations.jacoco.asPath}=destfile=${buildDir}/jacoco.exec,includes=*"
 }
 

--- a/spring-integration-voldemort/publish-maven.gradle
+++ b/spring-integration-voldemort/publish-maven.gradle
@@ -34,12 +34,12 @@ def customizePom(pom, gradleProject) {
 			url = linkHomepage
 			organization {
 				name = 'SpringSource'
-				url = 'http://springsource.org'
+				url = 'https://spring.io'
 			}
 			licenses {
 				license {
 					name 'The Apache Software License, Version 2.0'
-					url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+					url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
 					distribution 'repo'
 				}
 			}

--- a/spring-integration-xmpp-smack41/build.gradle
+++ b/spring-integration-xmpp-smack41/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'jacoco'
 
 buildscript {
 	repositories {
-		maven { url 'http://repo.spring.io/plugins-release' }
+		maven { url 'https://repo.spring.io/plugins-release' }
 	}
 	dependencies {
 		classpath 'io.spring.gradle:spring-io-plugin:0.0.4.RELEASE'
@@ -19,10 +19,10 @@ group = 'org.springframework.integration'
 
 repositories {
 	if (version.endsWith('BUILD-SNAPSHOT') || project.hasProperty('platformVersion')) {
-		maven { url 'http://repo.spring.io/libs-snapshot' }
+		maven { url 'https://repo.spring.io/libs-snapshot' }
 	}
-	maven { url 'http://repo.spring.io/libs-milestone' }
-//	maven { url 'http://repo.spring.io/libs-staging-local' }
+	maven { url 'https://repo.spring.io/libs-milestone' }
+//	maven { url 'https://repo.spring.io/libs-staging-local' }
 }
 
 if (project.hasProperty('platformVersion')) {
@@ -262,5 +262,5 @@ task dist(dependsOn: assemble) {
 task wrapper(type: Wrapper) {
 	description = 'Generates gradlew[.bat] scripts'
 	gradleVersion = '2.5'
-	distributionUrl = "http://services.gradle.org/distributions/gradle-${gradleVersion}-all.zip"
+	distributionUrl = "https://services.gradle.org/distributions/gradle-${gradleVersion}-all.zip"
 }

--- a/spring-integration-xmpp-smack41/publish-maven.gradle
+++ b/spring-integration-xmpp-smack41/publish-maven.gradle
@@ -34,12 +34,12 @@ def customizePom(pom, gradleProject) {
 			url = linkHomepage
 			organization {
 				name = 'SpringIO'
-				url = 'http://spring.io'
+				url = 'https://spring.io'
 			}
 			licenses {
 				license {
 					name 'The Apache Software License, Version 2.0'
-					url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+					url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
 					distribution 'repo'
 				}
 			}

--- a/spring-integration-xquery/pom.xml
+++ b/spring-integration-xquery/pom.xml
@@ -10,7 +10,7 @@
 	<licenses>
 		<license>
 			<name>The Apache Software License, Version 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+			<url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
 			<distribution>repo</distribution>
 		</license>
 	</licenses>

--- a/spring-integration-zip/build.gradle
+++ b/spring-integration-zip/build.gradle
@@ -25,7 +25,7 @@ group = 'org.springframework.integration'
 
 repositories {
 	if (version.endsWith('BUILD-SNAPSHOT') || project.hasProperty('platformVersion')) {
-		maven { url 'http://repo.spring.io/libs-snapshot' }
+		maven { url 'https://repo.spring.io/libs-snapshot' }
 	}
 	maven { url 'https://repo.spring.io/libs-milestone' }
 }

--- a/spring-integration-zip/publish-maven.gradle
+++ b/spring-integration-zip/publish-maven.gradle
@@ -34,12 +34,12 @@ def customizePom(pom, gradleProject) {
 			url = 'https://github.com/spring-projects/spring-integration-extensions'
 			organization {
 				name = 'SpringIO'
-				url = 'http://spring.io'
+				url = 'https://spring.io'
 			}
 			licenses {
 				license {
 					name 'The Apache Software License, Version 2.0'
-					url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+					url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
 					distribution 'repo'
 				}
 			}


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://services.gradle.org/distributions/gradle- (404) migrated to:  
  https://services.gradle.org/distributions/gradle- ([https](https://services.gradle.org/distributions/gradle-) result 404).

## Fixed Success 
These URLs were fixed successfully.

* http://projects.spring.io/spring-integration/ migrated to:  
  https://projects.spring.io/spring-integration/ ([https](https://projects.spring.io/spring-integration/) result 200).
* http://springsource.org (301) migrated to:  
  https://spring.io ([https](https://springsource.org) result 200).
* http://spring.io migrated to:  
  https://spring.io ([https](https://spring.io) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://www.project-voldemort.com/voldemort/configuration.html migrated to:  
  https://www.project-voldemort.com/voldemort/configuration.html ([https](https://www.project-voldemort.com/voldemort/configuration.html) result 200).
* http://repo.springsource.org/libs-milestone migrated to:  
  https://repo.springsource.org/libs-milestone ([https](https://repo.springsource.org/libs-milestone) result 301).
* http://repo.springsource.org/libs-snapshot migrated to:  
  https://repo.springsource.org/libs-snapshot ([https](https://repo.springsource.org/libs-snapshot) result 301).
* http://repo.springsource.org/plugins-release migrated to:  
  https://repo.springsource.org/plugins-release ([https](https://repo.springsource.org/plugins-release) result 301).
* http://www.gradle.org/docs/current/dsl/org.gradle.api.artifacts.ConfigurationContainer.html migrated to:  
  https://www.gradle.org/docs/current/dsl/org.gradle.api.artifacts.ConfigurationContainer.html ([https](https://www.gradle.org/docs/current/dsl/org.gradle.api.artifacts.ConfigurationContainer.html) result 301).
* http://www.gradle.org/docs/current/userguide/dependency_management.html migrated to:  
  https://www.gradle.org/docs/current/userguide/dependency_management.html ([https](https://www.gradle.org/docs/current/userguide/dependency_management.html) result 301).
* http://www.springsource.org/spring-integration migrated to:  
  https://www.springsource.org/spring-integration ([https](https://www.springsource.org/spring-integration) result 301).
* http://repo.spring.io/libs-milestone migrated to:  
  https://repo.spring.io/libs-milestone ([https](https://repo.spring.io/libs-milestone) result 302).
* http://repo.spring.io/libs-snapshot migrated to:  
  https://repo.spring.io/libs-snapshot ([https](https://repo.spring.io/libs-snapshot) result 302).
* http://repo.spring.io/libs-staging-local migrated to:  
  https://repo.spring.io/libs-staging-local ([https](https://repo.spring.io/libs-staging-local) result 302).
* http://repo.spring.io/plugins-release migrated to:  
  https://repo.spring.io/plugins-release ([https](https://repo.spring.io/plugins-release) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/xsd/maven-4.0.0.xsd
* http://www.w3.org/2001/XMLSchema-instance