### PR TITLE
URL Cleanup

### DIFF
--- a/samples/aws-s3/pom.xml
+++ b/samples/aws-s3/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.integration.samples</groupId>

--- a/samples/aws-s3/src/main/resources/META-INF/spring/integration/spring-integration-context.xml
+++ b/samples/aws-s3/src/main/resources/META-INF/spring/integration/spring-integration-context.xml
@@ -5,11 +5,11 @@
 	xmlns:int-file="http://www.springframework.org/schema/integration/file"
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:int-aws="http://www.springframework.org/schema/integration/aws"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/file http://www.springframework.org/schema/integration/file/spring-integration-file.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration/aws http://www.springframework.org/schema/integration/aws/spring-integration-aws.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/file https://www.springframework.org/schema/integration/file/spring-integration-file.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration/aws https://www.springframework.org/schema/integration/aws/spring-integration-aws.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<context:property-placeholder />
 

--- a/samples/kafka/src/main/resources/org/springframework/integration/samples/kafka/inbound/kafkaInboundAdapterParserTests-context.xml
+++ b/samples/kafka/src/main/resources/org/springframework/integration/samples/kafka/inbound/kafkaInboundAdapterParserTests-context.xml
@@ -4,10 +4,10 @@
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:stream="http://www.springframework.org/schema/integration/stream"
 	xmlns:int-kafka="http://www.springframework.org/schema/integration/kafka"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration/stream http://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd
-		http://www.springframework.org/schema/integration/kafka http://www.springframework.org/schema/integration/kafka/spring-integration-kafka.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/stream https://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd
+		http://www.springframework.org/schema/integration/kafka https://www.springframework.org/schema/integration/kafka/spring-integration-kafka.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<int:channel id="inputFromKafka"/>
 	<int:channel id="inputFromTransformer"/>

--- a/samples/kafka/src/main/resources/org/springframework/integration/samples/kafka/outbound/kafkaOutboundAdapterParserTests-context.xml
+++ b/samples/kafka/src/main/resources/org/springframework/integration/samples/kafka/outbound/kafkaOutboundAdapterParserTests-context.xml
@@ -5,12 +5,12 @@
        xmlns:int-kafka="http://www.springframework.org/schema/integration/kafka"
        xmlns:task="http://www.springframework.org/schema/task"
        xmlns:int-stream="http://www.springframework.org/schema/integration/stream"
-       xsi:schemaLocation="http://www.springframework.org/schema/integration/kafka http://www.springframework.org/schema/integration/kafka/spring-integration-kafka.xsd
-	http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd
+       xsi:schemaLocation="http://www.springframework.org/schema/integration/kafka https://www.springframework.org/schema/integration/kafka/spring-integration-kafka.xsd
+	http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+	http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	http://www.springframework.org/schema/task https://www.springframework.org/schema/task/spring-task.xsd
 	http://www.springframework.org/schema/integration/stream
-      http://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd">
+      https://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd">
 
 	<int:publish-subscribe-channel id="inputToKafka"/>
 

--- a/samples/mail-ses-integration/pom.xml
+++ b/samples/mail-ses-integration/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springframework.integration.samples</groupId>
 	<artifactId>mail-ses-integration</artifactId>

--- a/samples/mail-ses-integration/src/main/resources/META-INF/spring/integration/spring-integration-context.xml
+++ b/samples/mail-ses-integration/src/main/resources/META-INF/spring/integration/spring-integration-context.xml
@@ -7,13 +7,13 @@
 	xmlns:util="http://www.springframework.org/schema/util"
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:int-aws="http://www.springframework.org/schema/integration/aws"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration/mail http://www.springframework.org/schema/integration/mail/spring-integration-mail.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/file http://www.springframework.org/schema/integration/file/spring-integration-file.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
-		http://www.springframework.org/schema/integration/aws http://www.springframework.org/schema/integration/aws/spring-integration-aws.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/mail https://www.springframework.org/schema/integration/mail/spring-integration-mail.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/file https://www.springframework.org/schema/integration/file/spring-integration-file.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/integration/aws https://www.springframework.org/schema/integration/aws/spring-integration-aws.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<context:property-placeholder />
 

--- a/samples/mail-ses/pom.xml
+++ b/samples/mail-ses/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springframework.integration.samples</groupId>
 	<artifactId>mail-ses</artifactId>

--- a/samples/mail-ses/src/main/resources/META-INF/spring/integration/spring-integration-context.xml
+++ b/samples/mail-ses/src/main/resources/META-INF/spring/integration/spring-integration-context.xml
@@ -6,12 +6,12 @@
 	xmlns:int-mail="http://www.springframework.org/schema/integration/mail"
 	xmlns:util="http://www.springframework.org/schema/util"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration/mail http://www.springframework.org/schema/integration/mail/spring-integration-mail.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/file http://www.springframework.org/schema/integration/file/spring-integration-file.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/mail https://www.springframework.org/schema/integration/mail/spring-integration-mail.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/file https://www.springframework.org/schema/integration/file/spring-integration-file.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<context:property-placeholder />
 

--- a/samples/smb/pom.xml
+++ b/samples/smb/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.integration.samples</groupId>

--- a/samples/smb/src/main/resources/META-INF/spring/integration/spring-integration-context.xml
+++ b/samples/smb/src/main/resources/META-INF/spring/integration/spring-integration-context.xml
@@ -5,11 +5,11 @@
 	xmlns:int-smb="http://www.springframework.org/schema/integration/smb"
 	xmlns:int-file="http://www.springframework.org/schema/integration/file"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/file http://www.springframework.org/schema/integration/file/spring-integration-file.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration/smb http://www.springframework.org/schema/integration/smb/spring-integration-smb.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/file https://www.springframework.org/schema/integration/file/spring-integration-file.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration/smb https://www.springframework.org/schema/integration/smb/spring-integration-smb.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<context:property-placeholder />
 

--- a/samples/splunk/src/main/resources/org/springframework/integration/samples/splunk/SplunkCommon-context.xml
+++ b/samples/splunk/src/main/resources/org/springframework/integration/samples/splunk/SplunkCommon-context.xml
@@ -5,11 +5,11 @@
 	xmlns:int-splunk="http://www.springframework.org/schema/integration/splunk"
 	xmlns:stream="http://www.springframework.org/schema/integration/stream"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration/stream http://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd
-		http://www.springframework.org/schema/integration/splunk http://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/stream https://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd
+		http://www.springframework.org/schema/integration/splunk https://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
 	<context:component-scan base-package="org.springframework.integration.splunk"></context:component-scan>
 	<bean id="conversionService" class="org.springframework.context.support.ConversionServiceFactoryBean"/>

--- a/samples/splunk/src/main/resources/org/springframework/integration/samples/splunk/inbound/SplunkInboundChannelAdapterBlockingSample-context.xml
+++ b/samples/splunk/src/main/resources/org/springframework/integration/samples/splunk/inbound/SplunkInboundChannelAdapterBlockingSample-context.xml
@@ -5,11 +5,11 @@
 	xmlns:int-splunk="http://www.springframework.org/schema/integration/splunk"
 	xmlns:stream="http://www.springframework.org/schema/integration/stream"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration/stream http://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd
-		http://www.springframework.org/schema/integration/splunk http://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/stream https://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd
+		http://www.springframework.org/schema/integration/splunk https://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
 	<import resource="SplunkInboundChannelAdapterCommon-context.xml"/>
 	

--- a/samples/splunk/src/main/resources/org/springframework/integration/samples/splunk/inbound/SplunkInboundChannelAdapterCommon-context.xml
+++ b/samples/splunk/src/main/resources/org/springframework/integration/samples/splunk/inbound/SplunkInboundChannelAdapterCommon-context.xml
@@ -5,11 +5,11 @@
 	xmlns:int-splunk="http://www.springframework.org/schema/integration/splunk"
 	xmlns:stream="http://www.springframework.org/schema/integration/stream"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration/stream http://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd
-		http://www.springframework.org/schema/integration/splunk http://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/stream https://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd
+		http://www.springframework.org/schema/integration/splunk https://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.1.xsd">
 	
 	<import resource="../SplunkCommon-context.xml"/>
 	<context:component-scan base-package="org.springframework.integration.samples.splunk"></context:component-scan>

--- a/samples/splunk/src/main/resources/org/springframework/integration/samples/splunk/inbound/SplunkInboundChannelAdapterExportSample-context.xml
+++ b/samples/splunk/src/main/resources/org/springframework/integration/samples/splunk/inbound/SplunkInboundChannelAdapterExportSample-context.xml
@@ -5,11 +5,11 @@
 	xmlns:int-splunk="http://www.springframework.org/schema/integration/splunk"
 	xmlns:stream="http://www.springframework.org/schema/integration/stream"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration/stream http://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd
-		http://www.springframework.org/schema/integration/splunk http://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/stream https://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd
+		http://www.springframework.org/schema/integration/splunk https://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.1.xsd">
 	
 	<import resource="SplunkInboundChannelAdapterCommon-context.xml"/>
 	

--- a/samples/splunk/src/main/resources/org/springframework/integration/samples/splunk/inbound/SplunkInboundChannelAdapterNonBlockingSample-context.xml
+++ b/samples/splunk/src/main/resources/org/springframework/integration/samples/splunk/inbound/SplunkInboundChannelAdapterNonBlockingSample-context.xml
@@ -5,11 +5,11 @@
 	xmlns:int-splunk="http://www.springframework.org/schema/integration/splunk"
 	xmlns:stream="http://www.springframework.org/schema/integration/stream"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration/stream http://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd
-		http://www.springframework.org/schema/integration/splunk http://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/stream https://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd
+		http://www.springframework.org/schema/integration/splunk https://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.1.xsd">
 	
 	<import resource="SplunkInboundChannelAdapterCommon-context.xml"/>
 	

--- a/samples/splunk/src/main/resources/org/springframework/integration/samples/splunk/inbound/SplunkInboundChannelAdapterRealtimeSample-context.xml
+++ b/samples/splunk/src/main/resources/org/springframework/integration/samples/splunk/inbound/SplunkInboundChannelAdapterRealtimeSample-context.xml
@@ -5,11 +5,11 @@
 	xmlns:int-splunk="http://www.springframework.org/schema/integration/splunk"
 	xmlns:stream="http://www.springframework.org/schema/integration/stream"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration/stream http://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd
-		http://www.springframework.org/schema/integration/splunk http://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/stream https://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd
+		http://www.springframework.org/schema/integration/splunk https://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.1.xsd">
 	
 	<import resource="SplunkInboundChannelAdapterCommon-context.xml"/>
 	

--- a/samples/splunk/src/main/resources/org/springframework/integration/samples/splunk/inbound/SplunkInboundChannelAdapterSavedSample-context.xml
+++ b/samples/splunk/src/main/resources/org/springframework/integration/samples/splunk/inbound/SplunkInboundChannelAdapterSavedSample-context.xml
@@ -5,11 +5,11 @@
 	xmlns:int-splunk="http://www.springframework.org/schema/integration/splunk"
 	xmlns:stream="http://www.springframework.org/schema/integration/stream"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration/stream http://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd
-		http://www.springframework.org/schema/integration/splunk http://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/stream https://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd
+		http://www.springframework.org/schema/integration/splunk https://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.1.xsd">
 	
 	<import resource="SplunkInboundChannelAdapterCommon-context.xml"/>
 	

--- a/samples/splunk/src/main/resources/org/springframework/integration/samples/splunk/outbound/SplunkOutboundChannelAdapterCommon-context.xml
+++ b/samples/splunk/src/main/resources/org/springframework/integration/samples/splunk/outbound/SplunkOutboundChannelAdapterCommon-context.xml
@@ -5,13 +5,13 @@
 	xmlns:int-splunk="http://www.springframework.org/schema/integration/splunk"
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:jdbc="http://www.springframework.org/schema/jdbc" xmlns:int-jdbc="http://www.springframework.org/schema/integration/jdbc"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration/splunk http://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/stream http://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd
-		http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc.xsd
-		http://www.springframework.org/schema/integration/jdbc http://www.springframework.org/schema/integration/jdbc/spring-integration-jdbc.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/splunk https://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/stream https://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.1.xsd
+		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc.xsd
+		http://www.springframework.org/schema/integration/jdbc https://www.springframework.org/schema/integration/jdbc/spring-integration-jdbc.xsd">
 
 	<import resource="../SplunkCommon-context.xml" />
 

--- a/samples/splunk/src/main/resources/org/springframework/integration/samples/splunk/outbound/SplunkOutboundChannelAdapterStreamSample-context.xml
+++ b/samples/splunk/src/main/resources/org/springframework/integration/samples/splunk/outbound/SplunkOutboundChannelAdapterStreamSample-context.xml
@@ -4,10 +4,10 @@
 	xmlns:stream="http://www.springframework.org/schema/integration/stream"
 	xmlns:int-splunk="http://www.springframework.org/schema/integration/splunk"
 	xsi:schemaLocation="
-	http://www.springframework.org/schema/integration/stream http://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration/splunk http://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd">
+	http://www.springframework.org/schema/integration/stream https://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration/splunk https://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd">
 
 	<import resource="SplunkOutboundChannelAdapterCommon-context.xml"/>
 

--- a/samples/splunk/src/main/resources/org/springframework/integration/samples/splunk/outbound/SplunkOutboundChannelAdapterSubmitSample-context.xml
+++ b/samples/splunk/src/main/resources/org/springframework/integration/samples/splunk/outbound/SplunkOutboundChannelAdapterSubmitSample-context.xml
@@ -4,10 +4,10 @@
 	xmlns:stream="http://www.springframework.org/schema/integration/stream"
 	xmlns:int-splunk="http://www.springframework.org/schema/integration/splunk"
 	xsi:schemaLocation="
-	http://www.springframework.org/schema/integration/stream http://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration/splunk http://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd">
+	http://www.springframework.org/schema/integration/stream https://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration/splunk https://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd">
 
 	<import resource="SplunkOutboundChannelAdapterCommon-context.xml"/>
 	

--- a/samples/splunk/src/main/resources/org/springframework/integration/samples/splunk/outbound/SplunkOutboundChannelAdapterTcpSample-context.xml
+++ b/samples/splunk/src/main/resources/org/springframework/integration/samples/splunk/outbound/SplunkOutboundChannelAdapterTcpSample-context.xml
@@ -4,10 +4,10 @@
 	xmlns:stream="http://www.springframework.org/schema/integration/stream"
 	xmlns:int-splunk="http://www.springframework.org/schema/integration/splunk"
 	xsi:schemaLocation="
-	http://www.springframework.org/schema/integration/stream http://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration/splunk http://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd">
+	http://www.springframework.org/schema/integration/stream https://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration/splunk https://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd">
 
 	<import resource="SplunkOutboundChannelAdapterCommon-context.xml"/>
 

--- a/samples/voldemort/pom.xml
+++ b/samples/voldemort/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.integration.samples</groupId>

--- a/samples/voldemort/src/main/resources/META-INF/spring/integration/spring-integration-context.xml
+++ b/samples/voldemort/src/main/resources/META-INF/spring/integration/spring-integration-context.xml
@@ -3,15 +3,15 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-voldemort="http://www.springframework.org/schema/integration/voldemort"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration-2.2.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration/voldemort http://www.springframework.org/schema/integration/voldemort/spring-integration-voldemort.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration-2.2.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration/voldemort https://www.springframework.org/schema/integration/voldemort/spring-integration-voldemort.xsd">
 
 	<int:channel id="requestChannel"/>
 
 	<!-- See also:
-		http://static.springsource.org/spring-integration/reference/htmlsingle/#gateway-proxy
-		http://www.eaipatterns.com/MessagingGateway.html -->
+		https://docs.spring.io/spring-integration/reference/htmlsingle/#gateway-proxy
+		https://www.enterpriseintegrationpatterns.com/MessagingGateway.html -->
 	<int:gateway id="gateway"
 		default-request-timeout="5000"
 		default-reply-timeout="5000"

--- a/samples/xquery/pom.xml
+++ b/samples/xquery/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.integration.samples</groupId>

--- a/samples/xquery/src/main/resources/META-INF/spring/integration/spring-integration-context.xml
+++ b/samples/xquery/src/main/resources/META-INF/spring/integration/spring-integration-context.xml
@@ -2,9 +2,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-xquery="http://www.springframework.org/schema/integration/xquery"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration/xquery http://www.springframework.org/schema/integration/xquery/spring-integration-xquery.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration/xquery https://www.springframework.org/schema/integration/xquery/spring-integration-xquery.xsd">
 
 	<int:gateway id="gateway" default-request-timeout="5000"
 		default-reply-timeout="5000" default-request-channel="requestChannel"

--- a/samples/zip/pom.xml
+++ b/samples/zip/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.integration.samples</groupId>

--- a/samples/zip/src/main/resources/META-INF/spring/integration/spring-integration-context.xml
+++ b/samples/zip/src/main/resources/META-INF/spring/integration/spring-integration-context.xml
@@ -4,10 +4,10 @@
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-file="http://www.springframework.org/schema/integration/file"
 	xmlns:int-zip="http://www.springframework.org/schema/integration/zip"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/file http://www.springframework.org/schema/integration/file/spring-integration-file.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration/zip http://www.springframework.org/schema/integration/zip/spring-integration-zip.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/file https://www.springframework.org/schema/integration/file/spring-integration-file.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration/zip https://www.springframework.org/schema/integration/zip/spring-integration-zip.xsd">
 
 	<int-file:inbound-channel-adapter id="zipFilesIn"
 		directory="file:input-zip">

--- a/spring-integration-cassandra/src/checkstyle/checkstyle-suppressions.xml
+++ b/spring-integration-cassandra/src/checkstyle/checkstyle-suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE suppressions PUBLIC
     "-//Puppy Crawl//DTD Suppressions 1.1//EN"
-    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+    "https://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 <suppressions>
 	<suppress files="[\\/]test[\\/]" checks="AvoidStaticImport" />
 	<suppress files="[\\/]test[\\/]" checks="InnerTypeLast" />

--- a/spring-integration-cassandra/src/checkstyle/checkstyle.xml
+++ b/spring-integration-cassandra/src/checkstyle/checkstyle.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "https://www.puppycrawl.com/dtds/configuration_1_2.dtd">
 <module name="Checker">
 
 	<module name="SuppressionFilter">

--- a/spring-integration-cassandra/src/test/java/org/springframework/integration/cassandra/config/CassandraOutboundAdapterIntegrationTests-context.xml
+++ b/spring-integration-cassandra/src/test/java/org/springframework/integration/cassandra/config/CassandraOutboundAdapterIntegrationTests-context.xml
@@ -5,11 +5,11 @@
 	   xmlns:cassandra="http://www.springframework.org/schema/data/cassandra"
 	   xmlns:context="http://www.springframework.org/schema/context"
 	   xmlns:int-cassandra="http://www.springframework.org/schema/integration/cassandra"
-	   xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/data/cassandra http://www.springframework.org/schema/data/cassandra/spring-cassandra.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/integration/cassandra http://www.springframework.org/schema/integration/cassandra/spring-integration-cassandra.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/data/cassandra https://www.springframework.org/schema/data/cassandra/spring-cassandra.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/integration/cassandra https://www.springframework.org/schema/integration/cassandra/spring-integration-cassandra.xsd">
 
 
 	<context:property-placeholder location="classpath:cassandra.properties"/>

--- a/spring-integration-cassandra/src/test/java/org/springframework/integration/cassandra/config/CassandraOutboundAdapterParserTests-context.xml
+++ b/spring-integration-cassandra/src/test/java/org/springframework/integration/cassandra/config/CassandraOutboundAdapterParserTests-context.xml
@@ -3,9 +3,9 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:int="http://www.springframework.org/schema/integration"
 	   xmlns:int-cassandra="http://www.springframework.org/schema/integration/cassandra"
-	   xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration/cassandra http://www.springframework.org/schema/integration/cassandra/spring-integration-cassandra.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration/cassandra https://www.springframework.org/schema/integration/cassandra/spring-integration-cassandra.xsd">
 
 
 	<int:poller default="true" fixed-delay="50"/>

--- a/spring-integration-hazelcast/src/checkstyle/checkstyle-suppressions.xml
+++ b/spring-integration-hazelcast/src/checkstyle/checkstyle-suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE suppressions PUBLIC
     "-//Puppy Crawl//DTD Suppressions 1.1//EN"
-    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+    "https://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 <suppressions>
 	<suppress files="package-info\.java" checks=".*" />
 	<suppress files="[\\/]test[\\/]" checks="AvoidStaticImport" />

--- a/spring-integration-hazelcast/src/checkstyle/checkstyle.xml
+++ b/spring-integration-hazelcast/src/checkstyle/checkstyle.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "https://www.puppycrawl.com/dtds/configuration_1_2.dtd">
 <module name="Checker">
 
 	<module name="SuppressionFilter">

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/HazelcastIntegrationDefinitionValidatorTests-context.xml
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/HazelcastIntegrationDefinitionValidatorTests-context.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-    http://www.springframework.org/schema/beans/spring-beans.xsd">
+    https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="distList" factory-bean="hzInstance" factory-method="getList">
 		<constructor-arg value="distList"/>

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastCQDistributedMapInboundChannelAdapterTests-context.xml
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastCQDistributedMapInboundChannelAdapterTests-context.xml
@@ -4,11 +4,11 @@
 	   xmlns:int="http://www.springframework.org/schema/integration"
 	   xmlns:int-hazelcast="http://www.springframework.org/schema/integration/hazelcast"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-    http://www.springframework.org/schema/beans/spring-beans.xsd
+    https://www.springframework.org/schema/beans/spring-beans.xsd
     http://www.springframework.org/schema/integration
-    http://www.springframework.org/schema/integration/spring-integration.xsd
+    https://www.springframework.org/schema/integration/spring-integration.xsd
     http://www.springframework.org/schema/integration/hazelcast
-	http://www.springframework.org/schema/integration/hazelcast/spring-integration-hazelcast.xsd">
+	https://www.springframework.org/schema/integration/hazelcast/spring-integration-hazelcast.xsd">
 
 	<int:channel id="cqMapChannel1">
 		<int:queue/>

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastClusterMonitorInboundChannelAdapterTests-context.xml
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastClusterMonitorInboundChannelAdapterTests-context.xml
@@ -4,11 +4,11 @@
 	   xmlns:int="http://www.springframework.org/schema/integration"
 	   xmlns:int-hazelcast="http://www.springframework.org/schema/integration/hazelcast"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-    http://www.springframework.org/schema/beans/spring-beans.xsd
+    https://www.springframework.org/schema/beans/spring-beans.xsd
     http://www.springframework.org/schema/integration
-    http://www.springframework.org/schema/integration/spring-integration.xsd
+    https://www.springframework.org/schema/integration/spring-integration.xsd
     http://www.springframework.org/schema/integration/hazelcast
-	http://www.springframework.org/schema/integration/hazelcast/spring-integration-hazelcast.xsd">
+	https://www.springframework.org/schema/integration/hazelcast/spring-integration-hazelcast.xsd">
 
 	<int:channel id="cmChannel1">
 		<int:queue/>

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastDistributedListEventDrivenInboundChannelAdapterTests-context.xml
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastDistributedListEventDrivenInboundChannelAdapterTests-context.xml
@@ -4,11 +4,11 @@
 	   xmlns:int="http://www.springframework.org/schema/integration"
 	   xmlns:int-hazelcast="http://www.springframework.org/schema/integration/hazelcast"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-    http://www.springframework.org/schema/beans/spring-beans.xsd
+    https://www.springframework.org/schema/beans/spring-beans.xsd
     http://www.springframework.org/schema/integration
-    http://www.springframework.org/schema/integration/spring-integration.xsd
+    https://www.springframework.org/schema/integration/spring-integration.xsd
     http://www.springframework.org/schema/integration/hazelcast
-	http://www.springframework.org/schema/integration/hazelcast/spring-integration-hazelcast.xsd">
+	https://www.springframework.org/schema/integration/hazelcast/spring-integration-hazelcast.xsd">
 
 	<int:channel id="edListChannel1">
 		<int:queue/>

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastDistributedMapEventDrivenInboundChannelAdapterTests-context.xml
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastDistributedMapEventDrivenInboundChannelAdapterTests-context.xml
@@ -4,11 +4,11 @@
 	   xmlns:int="http://www.springframework.org/schema/integration"
 	   xmlns:int-hazelcast="http://www.springframework.org/schema/integration/hazelcast"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-    http://www.springframework.org/schema/beans/spring-beans.xsd
+    https://www.springframework.org/schema/beans/spring-beans.xsd
     http://www.springframework.org/schema/integration
-    http://www.springframework.org/schema/integration/spring-integration.xsd
+    https://www.springframework.org/schema/integration/spring-integration.xsd
     http://www.springframework.org/schema/integration/hazelcast
-	http://www.springframework.org/schema/integration/hazelcast/spring-integration-hazelcast.xsd">
+	https://www.springframework.org/schema/integration/hazelcast/spring-integration-hazelcast.xsd">
 
 	<int:channel id="edMapChannel1">
 		<int:queue/>

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastDistributedQueueEventDrivenInboundChannelAdapterTests-context.xml
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastDistributedQueueEventDrivenInboundChannelAdapterTests-context.xml
@@ -4,11 +4,11 @@
 	   xmlns:int="http://www.springframework.org/schema/integration"
 	   xmlns:int-hazelcast="http://www.springframework.org/schema/integration/hazelcast"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-    http://www.springframework.org/schema/beans/spring-beans.xsd
+    https://www.springframework.org/schema/beans/spring-beans.xsd
     http://www.springframework.org/schema/integration
-    http://www.springframework.org/schema/integration/spring-integration.xsd
+    https://www.springframework.org/schema/integration/spring-integration.xsd
     http://www.springframework.org/schema/integration/hazelcast
-	http://www.springframework.org/schema/integration/hazelcast/spring-integration-hazelcast.xsd">
+	https://www.springframework.org/schema/integration/hazelcast/spring-integration-hazelcast.xsd">
 
 	<int:channel id="edQueueChannel1">
 		<int:queue/>

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastDistributedSQLInboundChannelAdapterTests-context.xml
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastDistributedSQLInboundChannelAdapterTests-context.xml
@@ -4,11 +4,11 @@
 	   xmlns:int="http://www.springframework.org/schema/integration"
 	   xmlns:int-hazelcast="http://www.springframework.org/schema/integration/hazelcast"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-    http://www.springframework.org/schema/beans/spring-beans.xsd
+    https://www.springframework.org/schema/beans/spring-beans.xsd
     http://www.springframework.org/schema/integration
-    http://www.springframework.org/schema/integration/spring-integration.xsd
+    https://www.springframework.org/schema/integration/spring-integration.xsd
     http://www.springframework.org/schema/integration/hazelcast
-	http://www.springframework.org/schema/integration/hazelcast/spring-integration-hazelcast.xsd">
+	https://www.springframework.org/schema/integration/hazelcast/spring-integration-hazelcast.xsd">
 
 	<int:channel id="dsMapChannel1">
 		<int:queue/>

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastDistributedSetEventDrivenInboundChannelAdapterTests-context.xml
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastDistributedSetEventDrivenInboundChannelAdapterTests-context.xml
@@ -4,11 +4,11 @@
 	   xmlns:int="http://www.springframework.org/schema/integration"
 	   xmlns:int-hazelcast="http://www.springframework.org/schema/integration/hazelcast"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-    http://www.springframework.org/schema/beans/spring-beans.xsd
+    https://www.springframework.org/schema/beans/spring-beans.xsd
     http://www.springframework.org/schema/integration
-    http://www.springframework.org/schema/integration/spring-integration.xsd
+    https://www.springframework.org/schema/integration/spring-integration.xsd
     http://www.springframework.org/schema/integration/hazelcast
-	http://www.springframework.org/schema/integration/hazelcast/spring-integration-hazelcast.xsd">
+	https://www.springframework.org/schema/integration/hazelcast/spring-integration-hazelcast.xsd">
 
 	<int:channel id="edSetChannel1">
 		<int:queue/>

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastDistributedTopicEventDrivenInboundChannelAdapterTests-context.xml
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastDistributedTopicEventDrivenInboundChannelAdapterTests-context.xml
@@ -4,11 +4,11 @@
 	   xmlns:int="http://www.springframework.org/schema/integration"
 	   xmlns:int-hazelcast="http://www.springframework.org/schema/integration/hazelcast"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-    http://www.springframework.org/schema/beans/spring-beans.xsd
+    https://www.springframework.org/schema/beans/spring-beans.xsd
     http://www.springframework.org/schema/integration
-    http://www.springframework.org/schema/integration/spring-integration.xsd
+    https://www.springframework.org/schema/integration/spring-integration.xsd
     http://www.springframework.org/schema/integration/hazelcast
-	http://www.springframework.org/schema/integration/hazelcast/spring-integration-hazelcast.xsd">
+	https://www.springframework.org/schema/integration/hazelcast/spring-integration-hazelcast.xsd">
 
 	<int:channel id="edTopicChannel1">
 		<int:queue/>

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastMultiMapEventDrivenInboundChannelAdapterTests-context.xml
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastMultiMapEventDrivenInboundChannelAdapterTests-context.xml
@@ -4,11 +4,11 @@
 	   xmlns:int="http://www.springframework.org/schema/integration"
 	   xmlns:int-hazelcast="http://www.springframework.org/schema/integration/hazelcast"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-    http://www.springframework.org/schema/beans/spring-beans.xsd
+    https://www.springframework.org/schema/beans/spring-beans.xsd
     http://www.springframework.org/schema/integration
-    http://www.springframework.org/schema/integration/spring-integration.xsd
+    https://www.springframework.org/schema/integration/spring-integration.xsd
     http://www.springframework.org/schema/integration/hazelcast
-	http://www.springframework.org/schema/integration/hazelcast/spring-integration-hazelcast.xsd">
+	https://www.springframework.org/schema/integration/hazelcast/spring-integration-hazelcast.xsd">
 
 	<int:channel id="edMultiMapChannel1">
 		<int:queue/>

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastReplicatedMapEventDrivenInboundChannelAdapterTests-context.xml
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastReplicatedMapEventDrivenInboundChannelAdapterTests-context.xml
@@ -4,11 +4,11 @@
 	   xmlns:int="http://www.springframework.org/schema/integration"
 	   xmlns:int-hazelcast="http://www.springframework.org/schema/integration/hazelcast"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-    http://www.springframework.org/schema/beans/spring-beans.xsd
+    https://www.springframework.org/schema/beans/spring-beans.xsd
     http://www.springframework.org/schema/integration
-    http://www.springframework.org/schema/integration/spring-integration.xsd
+    https://www.springframework.org/schema/integration/spring-integration.xsd
     http://www.springframework.org/schema/integration/hazelcast
-	http://www.springframework.org/schema/integration/hazelcast/spring-integration-hazelcast.xsd">
+	https://www.springframework.org/schema/integration/hazelcast/spring-integration-hazelcast.xsd">
 
 	<int:channel id="edReplicatedMapChannel1">
 		<int:queue/>

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/outbound/HazelcastOutboundChannelAdapterTests-context.xml
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/outbound/HazelcastOutboundChannelAdapterTests-context.xml
@@ -4,11 +4,11 @@
 	   xmlns:int="http://www.springframework.org/schema/integration"
 	   xmlns:int-hazelcast="http://www.springframework.org/schema/integration/hazelcast"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-    http://www.springframework.org/schema/beans/spring-beans.xsd
+    https://www.springframework.org/schema/beans/spring-beans.xsd
     http://www.springframework.org/schema/integration
-    http://www.springframework.org/schema/integration/spring-integration.xsd
+    https://www.springframework.org/schema/integration/spring-integration.xsd
     http://www.springframework.org/schema/integration/hazelcast
-	http://www.springframework.org/schema/integration/hazelcast/spring-integration-hazelcast.xsd">
+	https://www.springframework.org/schema/integration/hazelcast/spring-integration-hazelcast.xsd">
 
 	<int:channel id="firstMapChannel"/>
 

--- a/spring-integration-jgroups/src/test/resources/custom-inbound-channel-adapter-header-mapper.xml
+++ b/spring-integration-jgroups/src/test/resources/custom-inbound-channel-adapter-header-mapper.xml
@@ -19,9 +19,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:jgroups="http://www.springframework.org/schema/integration/jgroups"
 	xmlns:int="http://www.springframework.org/schema/integration"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration/jgroups http://www.springframework.org/schema/integration/jgroups/spring-intergration-jgroups.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration-2.2.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/jgroups https://www.springframework.org/schema/integration/jgroups/spring-intergration-jgroups.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration-2.2.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 
 	<bean id="custom-header-mapper" class="org.springframework.integration.jgroups.CustomJGroupsHeaderMapper" />

--- a/spring-integration-jgroups/src/test/resources/inbound-channel-adapter.xml
+++ b/spring-integration-jgroups/src/test/resources/inbound-channel-adapter.xml
@@ -20,9 +20,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:jgroups="http://www.springframework.org/schema/integration/jgroups"
 	xmlns:int="http://www.springframework.org/schema/integration"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration/jgroups http://www.springframework.org/schema/integration/jgroups/spring-intergration-jgroups.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration-2.2.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/jgroups https://www.springframework.org/schema/integration/jgroups/spring-intergration-jgroups.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration-2.2.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 
 	<bean id="cluster"

--- a/spring-integration-jgroups/src/test/resources/jgroups-jchannel.xml
+++ b/spring-integration-jgroups/src/test/resources/jgroups-jchannel.xml
@@ -19,8 +19,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:jgroups="http://www.springframework.org/schema/integration/jgroups"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration/jgroups http://www.springframework.org/schema/integration/jgroups/spring-intergration-jgroups.xsd
-	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/jgroups https://www.springframework.org/schema/integration/jgroups/spring-intergration-jgroups.xsd
+	http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<jgroups:cluster name="cluster">
 		<jgroups:xml-configurator resource="classpath:udp.xml" />

--- a/spring-integration-jgroups/src/test/resources/outbound-channel-adapter.xml
+++ b/spring-integration-jgroups/src/test/resources/outbound-channel-adapter.xml
@@ -20,9 +20,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:jgroups="http://www.springframework.org/schema/integration/jgroups"
 	xmlns:int="http://www.springframework.org/schema/integration"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration/jgroups http://www.springframework.org/schema/integration/jgroups/spring-intergration-jgroups.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration-2.2.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/jgroups https://www.springframework.org/schema/integration/jgroups/spring-intergration-jgroups.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration-2.2.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 
 	<bean id="cluster"

--- a/spring-integration-print/src/test/java/org/springframework/integration/print/config/xml/PrintMessageHandlerParserTests-context.xml
+++ b/spring-integration-print/src/test/java/org/springframework/integration/print/config/xml/PrintMessageHandlerParserTests-context.xml
@@ -4,9 +4,9 @@
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-print="http://www.springframework.org/schema/integration/print"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration/print http://www.springframework.org/schema/integration/print/spring-integration-print.xsd">
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration/print https://www.springframework.org/schema/integration/print/spring-integration-print.xsd">
 	<int:channel id="input"/>
 
 	<bean id="printService" class="org.springframework.integration.print.support.MockPrintService"/>

--- a/spring-integration-print/src/test/java/org/springframework/integration/print/outbound/PrintOutboundChannelAdapterTest-context.xml
+++ b/spring-integration-print/src/test/java/org/springframework/integration/print/outbound/PrintOutboundChannelAdapterTest-context.xml
@@ -4,9 +4,9 @@
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-print="http://www.springframework.org/schema/integration/print"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration/print http://www.springframework.org/schema/integration/print/spring-integration-print.xsd">
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration/print https://www.springframework.org/schema/integration/print/spring-integration-print.xsd">
 	<int:channel id="input"/>
 
 	<int-print:outbound-channel-adapter id="printOutboundChannelAdapter"

--- a/spring-integration-smb/src/checkstyle/checkstyle-suppressions.xml
+++ b/spring-integration-smb/src/checkstyle/checkstyle-suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE suppressions PUBLIC
     "-//Puppy Crawl//DTD Suppressions 1.1//EN"
-    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+    "https://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 <suppressions>
 	<suppress files="package-info\.java" checks=".*" />
 	<suppress files="[\\/]test[\\/]" checks="RequireThis" />

--- a/spring-integration-smb/src/checkstyle/checkstyle.xml
+++ b/spring-integration-smb/src/checkstyle/checkstyle.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "https://www.puppycrawl.com/dtds/configuration_1_2.dtd">
 <module name="Checker">
 
 	<module name="SuppressionFilter">

--- a/spring-integration-smb/src/reference/docbook/resources.xml
+++ b/spring-integration-smb/src/reference/docbook/resources.xml
@@ -7,8 +7,8 @@
     <title>Spring Integration Home</title>
     <para>
       The definitive source of information about Spring Integration is the
-      <ulink url="http://www.springsource.org/spring-integration">Spring Integration Home</ulink> at
-      <ulink url="http://www.springsource.org">http://www.springsource.org</ulink>. That site serves as a hub of
+      <ulink url="https://www.springsource.org/spring-integration">Spring Integration Home</ulink> at
+      <ulink url="https://www.springsource.org">https://www.springsource.org</ulink>. That site serves as a hub of
       information and is the best place to find up-to-date announcements about the project as well as links to
       articles, blogs, and new sample applications.
     </para>

--- a/spring-integration-smb/src/test/java/org/springframework/integration/smb/SmbMessageHistoryTests-context.xml
+++ b/spring-integration-smb/src/test/java/org/springframework/integration/smb/SmbMessageHistoryTests-context.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-smb="http://www.springframework.org/schema/integration/smb"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration  http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/smb http://www.springframework.org/schema/integration/smb/spring-integration-smb.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration  https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/smb https://www.springframework.org/schema/integration/smb/spring-integration-smb.xsd">
 
 	<int:message-history/>
 

--- a/spring-integration-smb/src/test/java/org/springframework/integration/smb/SmbParserInboundTests-context.xml
+++ b/spring-integration-smb/src/test/java/org/springframework/integration/smb/SmbParserInboundTests-context.xml
@@ -4,9 +4,9 @@
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-smb="http://www.springframework.org/schema/integration/smb"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration  http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/smb http://www.springframework.org/schema/integration/smb/spring-integration-smb.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration  https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/smb https://www.springframework.org/schema/integration/smb/spring-integration-smb.xsd">
 
 	<bean id="smbSessionFactory" class="org.springframework.integration.smb.session.SmbSessionFactory">
 		<property name="host"        value="localhost"/>

--- a/spring-integration-smb/src/test/java/org/springframework/integration/smb/SmbParserInboundTests-fail-context.xml
+++ b/spring-integration-smb/src/test/java/org/springframework/integration/smb/SmbParserInboundTests-fail-context.xml
@@ -4,10 +4,10 @@
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-smb="http://www.springframework.org/schema/integration/smb"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration  http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/smb http://www.springframework.org/schema/integration/smb/spring-integration-smb.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration  https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/smb https://www.springframework.org/schema/integration/smb/spring-integration-smb.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<bean id="smbSessionFactory" class="org.springframework.integration.smb.session.SmbSessionFactory">
 		<property name="host"        value="localhost"/>

--- a/spring-integration-smb/src/test/java/org/springframework/integration/smb/config/SmbInboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-smb/src/test/java/org/springframework/integration/smb/config/SmbInboundChannelAdapterParserTests-context.xml
@@ -4,11 +4,11 @@
 	   xmlns:int="http://www.springframework.org/schema/integration"
 	   xmlns:int-smb="http://www.springframework.org/schema/integration/smb"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans.xsd
+		https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration
-		http://www.springframework.org/schema/integration/spring-integration.xsd
+		https://www.springframework.org/schema/integration/spring-integration.xsd
 		http://www.springframework.org/schema/integration/smb
-		http://www.springframework.org/schema/integration/smb/spring-integration-smb.xsd">
+		https://www.springframework.org/schema/integration/smb/spring-integration-smb.xsd">
 
 	<bean id="smbSessionFactory"
 		  class="org.springframework.integration.smb.config.SmbInboundChannelAdapterParserTests.TestSessionFactoryBean"/>

--- a/spring-integration-smb/src/test/java/org/springframework/integration/smb/config/SmbInboundChannelAdapterSample-context.xml
+++ b/spring-integration-smb/src/test/java/org/springframework/integration/smb/config/SmbInboundChannelAdapterSample-context.xml
@@ -4,9 +4,9 @@
 	xmlns:p="http://www.springframework.org/schema/p"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-smb="http://www.springframework.org/schema/integration/smb"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/smb http://www.springframework.org/schema/integration/smb/spring-integration-smb.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/smb https://www.springframework.org/schema/integration/smb/spring-integration-smb.xsd">
 
 	<bean id="smbSessionFactory"
 		class="org.springframework.integration.smb.session.SmbSessionFactory"

--- a/spring-integration-smb/src/test/java/org/springframework/integration/smb/config/SmbOutboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-smb/src/test/java/org/springframework/integration/smb/config/SmbOutboundChannelAdapterParserTests-context.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-smb="http://www.springframework.org/schema/integration/smb"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/smb http://www.springframework.org/schema/integration/smb/spring-integration-smb.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/smb https://www.springframework.org/schema/integration/smb/spring-integration-smb.xsd">
 
 	<bean id="smbSessionFactory" class="org.springframework.integration.smb.session.SmbSessionFactory">
 		<property name="host"        value="localhost"/>

--- a/spring-integration-smb/src/test/java/org/springframework/integration/smb/config/SmbOutboundChannelAdapterSample-context.xml
+++ b/spring-integration-smb/src/test/java/org/springframework/integration/smb/config/SmbOutboundChannelAdapterSample-context.xml
@@ -4,9 +4,9 @@
 	xmlns:p="http://www.springframework.org/schema/p"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-smb="http://www.springframework.org/schema/integration/smb"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/smb http://www.springframework.org/schema/integration/smb/spring-integration-smb.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/smb https://www.springframework.org/schema/integration/smb/spring-integration-smb.xsd">
 
 	<bean id="smbSessionFactory"
 		class="org.springframework.integration.smb.session.SmbSessionFactory"

--- a/spring-integration-smpp/src/reference/docbook/resources.xml
+++ b/spring-integration-smpp/src/reference/docbook/resources.xml
@@ -7,8 +7,8 @@
     <title>Spring Integration Home</title>
     <para>
       The definitive source of information about Spring Integration is the
-      <ulink url="http://www.springsource.org/spring-integration">Spring Integration Home</ulink> at
-      <ulink url="http://www.springsource.org">http://www.springsource.org</ulink>. That site serves as a hub of
+      <ulink url="https://www.springsource.org/spring-integration">Spring Integration Home</ulink> at
+      <ulink url="https://www.springsource.org">https://www.springsource.org</ulink>. That site serves as a hub of
       information and is the best place to find up-to-date announcements about the project as well as links to
       articles, blogs, and new sample applications.
     </para>
@@ -17,14 +17,14 @@
     <section id="smpp-home">
         <title>SMPP Home</title>
         <para>
-            You can get more information on SMPP from <ulink url="http://en.wikipedia.org/wiki/Short_Message_Peer-to-Peer"/>
+            You can get more information on SMPP from <ulink url="https://en.wikipedia.org/wiki/Short_Message_Peer-to-Peer"/>
         </para>
         <para>
             This adapter uses jsmpp as the underlying library to communicate with SMPP. Jsmpp is Java implementation of
-            SMPP protocol v3.4 and can be retrieved from <ulink url="http://code.google.com/p/jsmpp/"/>
+            SMPP protocol v3.4 and can be retrieved from <ulink url="https://code.google.com/p/jsmpp/"/>
         </para>
         <para>
-            You can get SMSC simulator from <ulink url="http://opensmpp.logica.com/CommonPart/Introduction/Introduction.htm#simulator"/>
+            You can get SMSC simulator from <ulink url="https://public.cgi.com/CommonPart/Introduction/Introduction.htm#simulator"/>
         </para>
 
     </section>

--- a/spring-integration-smpp/src/reference/docbook/smpp.xml
+++ b/spring-integration-smpp/src/reference/docbook/smpp.xml
@@ -31,11 +31,11 @@
        xmlns:int="http://www.springframework.org/schema/integration"
        xmlns:int-smpp="http://www.springframework.org/schema/integration/smpp"
        xsi:schemaLocation="http://www.springframework.org/schema/integration
-        http://www.springframework.org/schema/integration/spring-integration.xsd
+        https://www.springframework.org/schema/integration/spring-integration.xsd
 		http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans.xsd
+		https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration/smpp
-		http://www.springframework.org/schema/integration/smpp/spring-integration-smpp.xsd
+		https://www.springframework.org/schema/integration/smpp/spring-integration-smpp.xsd
 		">
 </beans>
         ]]>

--- a/spring-integration-smpp/src/test/resources/TestSmppConnection-context.xml
+++ b/spring-integration-smpp/src/test/resources/TestSmppConnection-context.xml
@@ -5,10 +5,10 @@
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-smpp="http://www.springframework.org/schema/integration/smpp"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/smpp http://www.springframework.org/schema/integration/smpp/spring-integration-smpp.xsd">
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/smpp https://www.springframework.org/schema/integration/smpp/spring-integration-smpp.xsd">
 
 	<import resource="classpath:smppConnection-context.xml"/>
 

--- a/spring-integration-smpp/src/test/resources/TestSmppInboundChannelAdapter-context.xml
+++ b/spring-integration-smpp/src/test/resources/TestSmppInboundChannelAdapter-context.xml
@@ -4,9 +4,9 @@
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:context="http://www.springframework.org/schema/context"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<import resource="classpath:smppConnection-context.xml"/>
 

--- a/spring-integration-smpp/src/test/resources/TestSmppInboundGateway-context.xml
+++ b/spring-integration-smpp/src/test/resources/TestSmppInboundGateway-context.xml
@@ -4,9 +4,9 @@
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:context="http://www.springframework.org/schema/context"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration  http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration  https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<import resource="classpath:smppConnection-context.xml"/>
 

--- a/spring-integration-smpp/src/test/resources/TestSmppOutboundChannelAdapter-context.xml
+++ b/spring-integration-smpp/src/test/resources/TestSmppOutboundChannelAdapter-context.xml
@@ -4,9 +4,9 @@
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:context="http://www.springframework.org/schema/context"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<import resource="classpath:smppConnection-context.xml"/>
 

--- a/spring-integration-smpp/src/test/resources/TestSmppOutboundChannelAdapterWithChain-context.xml
+++ b/spring-integration-smpp/src/test/resources/TestSmppOutboundChannelAdapterWithChain-context.xml
@@ -4,9 +4,9 @@
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-smpp="http://www.springframework.org/schema/integration/smpp"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration/smpp http://www.springframework.org/schema/integration/smpp/spring-integration-smpp.xsd">
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration/smpp https://www.springframework.org/schema/integration/smpp/spring-integration-smpp.xsd">
 
     <import resource="classpath:smppConnection-context.xml"/>
 

--- a/spring-integration-smpp/src/test/resources/TestSmppOutboundGateway-context.xml
+++ b/spring-integration-smpp/src/test/resources/TestSmppOutboundGateway-context.xml
@@ -4,9 +4,9 @@
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:context="http://www.springframework.org/schema/context"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration  http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration  https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<import resource="classpath:smppConnection-context.xml"/>
 

--- a/spring-integration-smpp/src/test/resources/TestSmppOutboundGatewayWithChain-context.xml
+++ b/spring-integration-smpp/src/test/resources/TestSmppOutboundGatewayWithChain-context.xml
@@ -4,9 +4,9 @@
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-smpp="http://www.springframework.org/schema/integration/smpp"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration/smpp http://www.springframework.org/schema/integration/smpp/spring-integration-smpp.xsd">
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration/smpp https://www.springframework.org/schema/integration/smpp/spring-integration-smpp.xsd">
 
     <import resource="classpath:smppConnection-context.xml"/>
 

--- a/spring-integration-smpp/src/test/resources/TestSmppServer-context.xml
+++ b/spring-integration-smpp/src/test/resources/TestSmppServer-context.xml
@@ -5,10 +5,10 @@
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-smpp="http://www.springframework.org/schema/integration/smpp"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/smpp http://www.springframework.org/schema/integration/smpp/spring-integration-smpp.xsd">
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/smpp https://www.springframework.org/schema/integration/smpp/spring-integration-smpp.xsd">
 
 	<import resource="classpath:smppConnection-context.xml"/>
 

--- a/spring-integration-smpp/src/test/resources/TestSmppSessionFactoryBean-context.xml
+++ b/spring-integration-smpp/src/test/resources/TestSmppSessionFactoryBean-context.xml
@@ -4,9 +4,9 @@
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:context="http://www.springframework.org/schema/context"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration  http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration  https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<import resource="classpath:smppConnection-context.xml"/>
 

--- a/spring-integration-smpp/src/test/resources/org/springframework/integration/smpp/config/xml/SmppInboundChannelAdapterParserTests.xml
+++ b/spring-integration-smpp/src/test/resources/org/springframework/integration/smpp/config/xml/SmppInboundChannelAdapterParserTests.xml
@@ -4,9 +4,9 @@
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-smpp="http://www.springframework.org/schema/integration/smpp"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration/smpp http://www.springframework.org/schema/integration/smpp/spring-integration-smpp.xsd">
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration/smpp https://www.springframework.org/schema/integration/smpp/spring-integration-smpp.xsd">
 
 	<int:channel id="out">
 		<int:queue capacity="1000" />

--- a/spring-integration-smpp/src/test/resources/org/springframework/integration/smpp/config/xml/SmppInboundGatewayParserTests.xml
+++ b/spring-integration-smpp/src/test/resources/org/springframework/integration/smpp/config/xml/SmppInboundGatewayParserTests.xml
@@ -5,10 +5,10 @@
 	xmlns:int-smpp="http://www.springframework.org/schema/integration/smpp"
 	xmlns:context="http://www.springframework.org/schema/context"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration/smpp http://www.springframework.org/schema/integration/smpp/spring-integration-smpp.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration/smpp https://www.springframework.org/schema/integration/smpp/spring-integration-smpp.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<!-- smpp configuration properties to test the gateway against real smpp
 		connection -->

--- a/spring-integration-smpp/src/test/resources/org/springframework/integration/smpp/config/xml/SmppOutboundChannelAdapterParserTests.xml
+++ b/spring-integration-smpp/src/test/resources/org/springframework/integration/smpp/config/xml/SmppOutboundChannelAdapterParserTests.xml
@@ -5,10 +5,10 @@
 	xmlns:int-smpp="http://www.springframework.org/schema/integration/smpp"
 	xmlns:context="http://www.springframework.org/schema/context"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration/smpp http://www.springframework.org/schema/integration/smpp/spring-integration-smpp.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration/smpp https://www.springframework.org/schema/integration/smpp/spring-integration-smpp.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<!-- smpp configuration properties to test the gateway against real smpp
 		connection -->

--- a/spring-integration-smpp/src/test/resources/org/springframework/integration/smpp/config/xml/SmppOutboundGatewayParserTests.xml
+++ b/spring-integration-smpp/src/test/resources/org/springframework/integration/smpp/config/xml/SmppOutboundGatewayParserTests.xml
@@ -5,10 +5,10 @@
 	xmlns:int-smpp="http://www.springframework.org/schema/integration/smpp"
 	xmlns:context="http://www.springframework.org/schema/context"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration/smpp http://www.springframework.org/schema/integration/smpp/spring-integration-smpp.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration/smpp https://www.springframework.org/schema/integration/smpp/spring-integration-smpp.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<!-- smpp configuration properties to test the gateway against real smpp
 		connection -->

--- a/spring-integration-smpp/src/test/resources/smppConnection-context.xml
+++ b/spring-integration-smpp/src/test/resources/smppConnection-context.xml
@@ -4,10 +4,10 @@
 	xmlns:integration="http://www.springframework.org/schema/integration"
 	xmlns:smpp="http://www.springframework.org/schema/integration/smpp"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/smpp http://www.springframework.org/schema/integration/smpp/spring-integration-smpp.xsd">
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/smpp https://www.springframework.org/schema/integration/smpp/spring-integration-smpp.xsd">
 
 	<context:property-placeholder location="smpp.properties" />
 

--- a/spring-integration-social-twitter/src/checkstyle/checkstyle-suppressions.xml
+++ b/spring-integration-social-twitter/src/checkstyle/checkstyle-suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE suppressions PUBLIC
     "-//Puppy Crawl//DTD Suppressions 1.1//EN"
-    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+    "https://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 <suppressions>
 	<suppress files="package-info\.java" checks=".*" />
 	<suppress files="[\\/]test[\\/]" checks="AvoidStaticImport" />

--- a/spring-integration-social-twitter/src/checkstyle/checkstyle.xml
+++ b/spring-integration-social-twitter/src/checkstyle/checkstyle.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "https://www.puppycrawl.com/dtds/configuration_1_2.dtd">
 <module name="Checker">
 
 	<module name="SuppressionFilter">

--- a/spring-integration-social-twitter/src/test/java/org/springframework/integration/twitter/config/OutboundAdapterWithRHACWithinChain-fail-context.xml
+++ b/spring-integration-social-twitter/src/test/java/org/springframework/integration/twitter/config/OutboundAdapterWithRHACWithinChain-fail-context.xml
@@ -3,9 +3,9 @@
 		xmlns:beans="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:twitter="http://www.springframework.org/schema/integration/twitter"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-						http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-						http://www.springframework.org/schema/integration/twitter http://www.springframework.org/schema/integration/twitter/spring-integration-social-twitter.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+						http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+						http://www.springframework.org/schema/integration/twitter https://www.springframework.org/schema/integration/twitter/spring-integration-social-twitter.xsd">
 
 	<beans:bean id="twitter" class="org.springframework.social.twitter.api.impl.TwitterTemplate"/>
 

--- a/spring-integration-social-twitter/src/test/java/org/springframework/integration/twitter/config/TestReceivingMessageSourceParser-context.xml
+++ b/spring-integration-social-twitter/src/test/java/org/springframework/integration/twitter/config/TestReceivingMessageSourceParser-context.xml
@@ -4,9 +4,9 @@
 		xmlns:beans="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:twitter="http://www.springframework.org/schema/integration/twitter"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-						http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-						http://www.springframework.org/schema/integration/twitter http://www.springframework.org/schema/integration/twitter/spring-integration-social-twitter.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+						http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+						http://www.springframework.org/schema/integration/twitter https://www.springframework.org/schema/integration/twitter/spring-integration-social-twitter.xsd">
 
 	<beans:bean id="twitter" class="org.mockito.Mockito" factory-method="mock">
 		<beans:constructor-arg value="org.springframework.social.twitter.api.Twitter"/>

--- a/spring-integration-social-twitter/src/test/java/org/springframework/integration/twitter/config/TestSearchReceivingMessageSourceParser-context.xml
+++ b/spring-integration-social-twitter/src/test/java/org/springframework/integration/twitter/config/TestSearchReceivingMessageSourceParser-context.xml
@@ -4,9 +4,9 @@
 		xmlns:beans="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:twitter="http://www.springframework.org/schema/integration/twitter"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-						http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-						http://www.springframework.org/schema/integration/twitter http://www.springframework.org/schema/integration/twitter/spring-integration-social-twitter.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+						http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+						http://www.springframework.org/schema/integration/twitter https://www.springframework.org/schema/integration/twitter/spring-integration-social-twitter.xsd">
 
 	<channel id="searchChannel"/>
 

--- a/spring-integration-social-twitter/src/test/java/org/springframework/integration/twitter/config/TestSendingMessageHandlerParser-context.xml
+++ b/spring-integration-social-twitter/src/test/java/org/springframework/integration/twitter/config/TestSendingMessageHandlerParser-context.xml
@@ -4,9 +4,9 @@
         xmlns:beans="http://www.springframework.org/schema/beans"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns:twitter="http://www.springframework.org/schema/integration/twitter"
-        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-						http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-						http://www.springframework.org/schema/integration/twitter http://www.springframework.org/schema/integration/twitter/spring-integration-social-twitter.xsd">
+        xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+						http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+						http://www.springframework.org/schema/integration/twitter https://www.springframework.org/schema/integration/twitter/spring-integration-social-twitter.xsd">
 
 	<beans:bean id="twitter" class="org.springframework.social.twitter.api.impl.TwitterTemplate">
 		<beans:constructor-arg name="clientToken" value="myDummyClientToken"/>

--- a/spring-integration-social-twitter/src/test/java/org/springframework/integration/twitter/config/TwitterSearchOutboundGatewayParserTests-context.xml
+++ b/spring-integration-social-twitter/src/test/java/org/springframework/integration/twitter/config/TwitterSearchOutboundGatewayParserTests-context.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-twitter="http://www.springframework.org/schema/integration/twitter"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/twitter http://www.springframework.org/schema/integration/twitter/spring-integration-social-twitter.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/twitter https://www.springframework.org/schema/integration/twitter/spring-integration-social-twitter.xsd">
 
 	<bean id="tt" class="org.mockito.Mockito" factory-method="mock">
 		<constructor-arg value="org.springframework.social.twitter.api.Twitter" />

--- a/spring-integration-social-twitter/src/test/java/org/springframework/integration/twitter/ignored/TestReceivingUsingNamespace-context.xml
+++ b/spring-integration-social-twitter/src/test/java/org/springframework/integration/twitter/ignored/TestReceivingUsingNamespace-context.xml
@@ -5,10 +5,10 @@
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
 		xmlns:twitter="http://www.springframework.org/schema/integration/twitter"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-						http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-						http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-						http://www.springframework.org/schema/integration/twitter http://www.springframework.org/schema/integration/twitter/spring-integration-social-twitter.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+						http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+						http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+						http://www.springframework.org/schema/integration/twitter https://www.springframework.org/schema/integration/twitter/spring-integration-social-twitter.xsd">
 
 	<message-history/>
 

--- a/spring-integration-social-twitter/src/test/java/org/springframework/integration/twitter/ignored/TestSearchOutboundGateway-context.xml
+++ b/spring-integration-social-twitter/src/test/java/org/springframework/integration/twitter/ignored/TestSearchOutboundGateway-context.xml
@@ -5,10 +5,10 @@
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
 		xmlns:twitter="http://www.springframework.org/schema/integration/twitter"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-						http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-						http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-						http://www.springframework.org/schema/integration/twitter http://www.springframework.org/schema/integration/twitter/spring-integration-social-twitter.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+						http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+						http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+						http://www.springframework.org/schema/integration/twitter https://www.springframework.org/schema/integration/twitter/spring-integration-social-twitter.xsd">
 
 	<message-history/>
 

--- a/spring-integration-social-twitter/src/test/java/org/springframework/integration/twitter/ignored/TestSendingDMsUsingNamespace-context.xml
+++ b/spring-integration-social-twitter/src/test/java/org/springframework/integration/twitter/ignored/TestSendingDMsUsingNamespace-context.xml
@@ -5,10 +5,10 @@
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
 		xmlns:twitter="http://www.springframework.org/schema/integration/twitter"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-						http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-					 	http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-						http://www.springframework.org/schema/integration/twitter http://www.springframework.org/schema/integration/twitter/spring-integration-social-twitter.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+						http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+					 	http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+						http://www.springframework.org/schema/integration/twitter https://www.springframework.org/schema/integration/twitter/spring-integration-social-twitter.xsd">
 
 	<context:property-placeholder
 			location="classpath:twitter.sender.properties"

--- a/spring-integration-social-twitter/src/test/java/org/springframework/integration/twitter/ignored/TestSendingUpdatesUsingNamespace-context.xml
+++ b/spring-integration-social-twitter/src/test/java/org/springframework/integration/twitter/ignored/TestSendingUpdatesUsingNamespace-context.xml
@@ -5,10 +5,10 @@
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
 		xmlns:twitter="http://www.springframework.org/schema/integration/twitter"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-						http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-					 	http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-						http://www.springframework.org/schema/integration/twitter http://www.springframework.org/schema/integration/twitter/spring-integration-social-twitter.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+						http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+					 	http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+						http://www.springframework.org/schema/integration/twitter https://www.springframework.org/schema/integration/twitter/spring-integration-social-twitter.xsd">
 
 	<context:property-placeholder
 			location="classpath:twitter.receiver.properties"

--- a/spring-integration-social-twitter/src/test/java/org/springframework/integration/twitter/inbound/SearchReceivingMessageSourceWithMetadataTests-context.xml
+++ b/spring-integration-social-twitter/src/test/java/org/springframework/integration/twitter/inbound/SearchReceivingMessageSourceWithMetadataTests-context.xml
@@ -4,10 +4,10 @@
 	   xmlns:int="http://www.springframework.org/schema/integration"
 	   xmlns:int-twitter="http://www.springframework.org/schema/integration/twitter"
 	   xmlns:context="http://www.springframework.org/schema/context"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/twitter http://www.springframework.org/schema/integration/twitter/spring-integration-social-twitter.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/twitter https://www.springframework.org/schema/integration/twitter/spring-integration-social-twitter.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<context:annotation-config/>
 

--- a/spring-integration-social-twitter/src/test/java/org/springframework/integration/twitter/outbound/StatusUpdatingMessageHandlerTests-context.xml
+++ b/spring-integration-social-twitter/src/test/java/org/springframework/integration/twitter/outbound/StatusUpdatingMessageHandlerTests-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int-twitter="http://www.springframework.org/schema/integration/twitter"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration/twitter http://www.springframework.org/schema/integration/twitter/spring-integration-social-twitter.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration/twitter https://www.springframework.org/schema/integration/twitter/spring-integration-social-twitter.xsd">
 
 	<bean id="tt" class="org.mockito.Mockito" factory-method="mock">
 		<constructor-arg value="org.springframework.social.twitter.api.Twitter" />

--- a/spring-integration-voldemort/src/reference/docbook/resources.xml
+++ b/spring-integration-voldemort/src/reference/docbook/resources.xml
@@ -7,8 +7,8 @@
         <title>Spring Integration Home</title>
         <para>
             The definitive source of information about Spring Integration is the
-            <ulink url="http://www.springsource.org/spring-integration">Spring Integration Home</ulink>
-            at <ulink url="http://www.springsource.org">http://www.springsource.org</ulink>. That site serves as a hub
+            <ulink url="https://www.springsource.org/spring-integration">Spring Integration Home</ulink>
+            at <ulink url="https://www.springsource.org">https://www.springsource.org</ulink>. That site serves as a hub
             of information and is the best place to find up-to-date announcements about the project as well as links to
             articles, blogs, and new sample applications.
         </para>
@@ -18,7 +18,7 @@
         <title>Project Voldemort Home</title>
         <para>
             If you are not familiar with Voldemort distributed key-value store, please visit
-            <ulink url="http://www.project-voldemort.com">Project Voldemort</ulink> homepage. Hereby site contains
+            <ulink url="https://www.project-voldemort.com">Project Voldemort</ulink> homepage. Hereby site contains
             complete design overview, list of available configuration options and documentation of client API. Links
             to source code, bug tracker and wiki can be found as well.
         </para>

--- a/spring-integration-voldemort/src/test/resources/org/springframework/integration/voldemort/test/common-test-context.xml
+++ b/spring-integration-voldemort/src/test/resources/org/springframework/integration/voldemort/test/common-test-context.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="
-	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="config" class="voldemort.client.ClientConfig">
 		<property name="bootstrapUrls" value="tcp://localhost:6666" />

--- a/spring-integration-voldemort/src/test/resources/org/springframework/integration/voldemort/test/inbound/ObjectKeyTest-context.xml
+++ b/spring-integration-voldemort/src/test/resources/org/springframework/integration/voldemort/test/inbound/ObjectKeyTest-context.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-voldemort="http://www.springframework.org/schema/integration/voldemort"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/voldemort http://www.springframework.org/schema/integration/voldemort/spring-integration-voldemort.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/voldemort https://www.springframework.org/schema/integration/voldemort/spring-integration-voldemort.xsd">
 
 	<import resource="../common-test-context.xml" />
 

--- a/spring-integration-voldemort/src/test/resources/org/springframework/integration/voldemort/test/inbound/VoldemortInboundAdapterTest-context.xml
+++ b/spring-integration-voldemort/src/test/resources/org/springframework/integration/voldemort/test/inbound/VoldemortInboundAdapterTest-context.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-voldemort="http://www.springframework.org/schema/integration/voldemort"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/voldemort http://www.springframework.org/schema/integration/voldemort/spring-integration-voldemort.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/voldemort https://www.springframework.org/schema/integration/voldemort/spring-integration-voldemort.xsd">
 
 	<import resource="../common-test-context.xml" />
 

--- a/spring-integration-voldemort/src/test/resources/org/springframework/integration/voldemort/test/outbound/ObjectKeyTest-context.xml
+++ b/spring-integration-voldemort/src/test/resources/org/springframework/integration/voldemort/test/outbound/ObjectKeyTest-context.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-voldemort="http://www.springframework.org/schema/integration/voldemort"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/voldemort http://www.springframework.org/schema/integration/voldemort/spring-integration-voldemort.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/voldemort https://www.springframework.org/schema/integration/voldemort/spring-integration-voldemort.xsd">
 
 	<import resource="../common-test-context.xml" />
 

--- a/spring-integration-voldemort/src/test/resources/org/springframework/integration/voldemort/test/outbound/VoldemortOutboundAdapterTest-context.xml
+++ b/spring-integration-voldemort/src/test/resources/org/springframework/integration/voldemort/test/outbound/VoldemortOutboundAdapterTest-context.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-voldemort="http://www.springframework.org/schema/integration/voldemort"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/voldemort http://www.springframework.org/schema/integration/voldemort/spring-integration-voldemort.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/voldemort https://www.springframework.org/schema/integration/voldemort/spring-integration-voldemort.xsd">
 
 	<import resource="../common-test-context.xml" />
 

--- a/spring-integration-voldemort/src/test/resources/org/springframework/integration/voldemort/test/store/VoldemortMessageStoreAggregationTest-context.xml
+++ b/spring-integration-voldemort/src/test/resources/org/springframework/integration/voldemort/test/store/VoldemortMessageStoreAggregationTest-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd">
 
 	<import resource="store-test-context.xml" />
 

--- a/spring-integration-voldemort/src/test/resources/org/springframework/integration/voldemort/test/store/store-test-context.xml
+++ b/spring-integration-voldemort/src/test/resources/org/springframework/integration/voldemort/test/store/store-test-context.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="config" class="voldemort.client.ClientConfig">
 		<property name="bootstrapUrls" value="tcp://localhost:6666" />

--- a/spring-integration-xmpp-smack41/src/test/java/org/springframework/integration/xmpp/config/ChatMessageInboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-xmpp-smack41/src/test/java/org/springframework/integration/xmpp/config/ChatMessageInboundChannelAdapterParserTests-context.xml
@@ -5,9 +5,9 @@
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:xmpp="http://www.springframework.org/schema/integration/xmpp"
 		xsi:schemaLocation="http://www.springframework.org/schema/integration/xmpp
-				http://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp.xsd
-				http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-				http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
+				https://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp.xsd
+				http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+				http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd">
 
 	<beans:bean id="testConnection" class="org.mockito.Mockito" factory-method="mock">
 		<beans:constructor-arg value="org.jivesoftware.smack.XMPPConnection"/>

--- a/spring-integration-xmpp-smack41/src/test/java/org/springframework/integration/xmpp/config/ChatMessageOutboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-xmpp-smack41/src/test/java/org/springframework/integration/xmpp/config/ChatMessageOutboundChannelAdapterParserTests-context.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/xmpp http://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp.xsd"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/xmpp https://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp.xsd"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-xmpp="http://www.springframework.org/schema/integration/xmpp">
 

--- a/spring-integration-xmpp-smack41/src/test/java/org/springframework/integration/xmpp/config/PresenceInboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-xmpp-smack41/src/test/java/org/springframework/integration/xmpp/config/PresenceInboundChannelAdapterParserTests-context.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/xmpp http://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp.xsd"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/xmpp https://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp.xsd"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-xmpp="http://www.springframework.org/schema/integration/xmpp">
 

--- a/spring-integration-xmpp-smack41/src/test/java/org/springframework/integration/xmpp/config/PresenceOutboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-xmpp-smack41/src/test/java/org/springframework/integration/xmpp/config/PresenceOutboundChannelAdapterParserTests-context.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/xmpp http://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp.xsd"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/xmpp https://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp.xsd"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-xmpp="http://www.springframework.org/schema/integration/xmpp">
 

--- a/spring-integration-xmpp-smack41/src/test/java/org/springframework/integration/xmpp/config/XmppConnectionFactoryBeanTests-context.xml
+++ b/spring-integration-xmpp-smack41/src/test/java/org/springframework/integration/xmpp/config/XmppConnectionFactoryBeanTests-context.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/xmpp http://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp.xsd"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/xmpp https://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp.xsd"
 	   xmlns:int="http://www.springframework.org/schema/integration"
 	   xmlns:int-xmpp="http://www.springframework.org/schema/integration/xmpp">
 

--- a/spring-integration-xmpp-smack41/src/test/java/org/springframework/integration/xmpp/config/XmppConnectionParserTests-complete.xml
+++ b/spring-integration-xmpp-smack41/src/test/java/org/springframework/integration/xmpp/config/XmppConnectionParserTests-complete.xml
@@ -4,10 +4,10 @@
 	xmlns:int-xmpp="http://www.springframework.org/schema/integration/xmpp"
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:util="http://www.springframework.org/schema/util"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration/xmpp http://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/xmpp https://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<context:property-placeholder properties-ref="props"/>
 

--- a/spring-integration-xmpp-smack41/src/test/java/org/springframework/integration/xmpp/config/XmppConnectionParserTests-simple.xml
+++ b/spring-integration-xmpp-smack41/src/test/java/org/springframework/integration/xmpp/config/XmppConnectionParserTests-simple.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:int-xmpp="http://www.springframework.org/schema/integration/xmpp"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration/xmpp http://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration/xmpp https://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp.xsd">
 
 	<int-xmpp:xmpp-connection id="connection"
 							  user="happy.user@my.domain" password="blah" host="localhost" auto-startup="false"/>

--- a/spring-integration-xmpp-smack41/src/test/java/org/springframework/integration/xmpp/config/XmppHeaderEnricherParserTests-context.xml
+++ b/spring-integration-xmpp-smack41/src/test/java/org/springframework/integration/xmpp/config/XmppHeaderEnricherParserTests-context.xml
@@ -4,9 +4,9 @@
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:xmpp="http://www.springframework.org/schema/integration/xmpp"
 		xsi:schemaLocation="
-        http://www.springframework.org/schema/integration/xmpp http://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp.xsd
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
+        http://www.springframework.org/schema/integration/xmpp https://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd">
 
 	<channel id="input"/>
 	<channel id="output"/>

--- a/spring-integration-xmpp-smack41/src/test/java/org/springframework/integration/xmpp/ignore/ConsoleChatTests-context.xml
+++ b/spring-integration-xmpp-smack41/src/test/java/org/springframework/integration/xmpp/ignore/ConsoleChatTests-context.xml
@@ -5,14 +5,14 @@
 			 xmlns:util="http://www.springframework.org/schema/util" xmlns:xmpp="http://www.springframework.org/schema/integration/xmpp"
 			 xmlns:tool="http://www.springframework.org/schema/tool" xmlns:lang="http://www.springframework.org/schema/lang"
 			 xmlns:console="http://www.springframework.org/schema/integration/stream"
-			 xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/tool http://www.springframework.org/schema/tool/spring-tool.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration/xmpp http://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
-		http://www.springframework.org/schema/lang http://www.springframework.org/schema/lang/spring-lang.xsd
-		http://www.springframework.org/schema/integration/stream http://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd">
+			 xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/tool https://www.springframework.org/schema/tool/spring-tool.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration/xmpp https://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/lang https://www.springframework.org/schema/lang/spring-lang.xsd
+		http://www.springframework.org/schema/integration/stream https://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd">
 
 	<beans:bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
 		<beans:property name="location" value="classpath:test.properties"/>

--- a/spring-integration-xmpp-smack41/src/test/java/org/springframework/integration/xmpp/ignore/InboundChatTests-context.xml
+++ b/spring-integration-xmpp-smack41/src/test/java/org/springframework/integration/xmpp/ignore/InboundChatTests-context.xml
@@ -10,13 +10,13 @@
 		xmlns:tool="http://www.springframework.org/schema/tool"
 		xmlns:lang="http://www.springframework.org/schema/lang"
 		xsi:schemaLocation="http://www.springframework.org/schema/integration/xmpp
-		http://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp.xsd
-						http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-						http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-						http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-						http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
-						http://www.springframework.org/schema/tool http://www.springframework.org/schema/tool/spring-tool.xsd
-						http://www.springframework.org/schema/lang http://www.springframework.org/schema/lang/spring-lang.xsd">
+		https://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp.xsd
+						http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+						http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+						http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+						http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
+						http://www.springframework.org/schema/tool https://www.springframework.org/schema/tool/spring-tool.xsd
+						http://www.springframework.org/schema/lang https://www.springframework.org/schema/lang/spring-lang.xsd">
 
 	<context:property-placeholder location="classpath:test.properties"/>
 

--- a/spring-integration-xmpp-smack41/src/test/java/org/springframework/integration/xmpp/ignore/InboundPresenceTests-context.xml
+++ b/spring-integration-xmpp-smack41/src/test/java/org/springframework/integration/xmpp/ignore/InboundPresenceTests-context.xml
@@ -5,14 +5,14 @@
 			 xmlns:util="http://www.springframework.org/schema/util" xmlns:xmpp="http://www.springframework.org/schema/integration/xmpp"
 			 xmlns:tool="http://www.springframework.org/schema/tool" xmlns:lang="http://www.springframework.org/schema/lang"
 			 xmlns:stream="http://www.springframework.org/schema/integration/stream"
-			 xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/tool http://www.springframework.org/schema/tool/spring-tool.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration/xmpp http://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
-		http://www.springframework.org/schema/lang http://www.springframework.org/schema/lang/spring-lang.xsd
-		http://www.springframework.org/schema/integration/stream http://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd">
+			 xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/tool https://www.springframework.org/schema/tool/spring-tool.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration/xmpp https://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/lang https://www.springframework.org/schema/lang/spring-lang.xsd
+		http://www.springframework.org/schema/integration/stream https://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd">
 
 	<beans:bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
 		<beans:property name="location" value="classpath:test.properties"/>

--- a/spring-integration-xmpp-smack41/src/test/java/org/springframework/integration/xmpp/ignore/OutboundChatTests-context.xml
+++ b/spring-integration-xmpp-smack41/src/test/java/org/springframework/integration/xmpp/ignore/OutboundChatTests-context.xml
@@ -4,13 +4,13 @@
 			 xmlns:p="http://www.springframework.org/schema/p" xmlns:context="http://www.springframework.org/schema/context"
 			 xmlns:util="http://www.springframework.org/schema/util" xmlns:xmpp="http://www.springframework.org/schema/integration/xmpp"
 			 xmlns:tool="http://www.springframework.org/schema/tool" xmlns:lang="http://www.springframework.org/schema/lang"
-			 xsi:schemaLocation="http://www.springframework.org/schema/integration/xmpp http://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp.xsd
-						http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-						http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-						http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-						http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
-						http://www.springframework.org/schema/tool http://www.springframework.org/schema/tool/spring-tool.xsd
-						http://www.springframework.org/schema/lang http://www.springframework.org/schema/lang/spring-lang.xsd">
+			 xsi:schemaLocation="http://www.springframework.org/schema/integration/xmpp https://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp.xsd
+						http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+						http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+						http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+						http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
+						http://www.springframework.org/schema/tool https://www.springframework.org/schema/tool/spring-tool.xsd
+						http://www.springframework.org/schema/lang https://www.springframework.org/schema/lang/spring-lang.xsd">
 
 	<context:property-placeholder location="classpath:test.properties"/>
 

--- a/spring-integration-xmpp-smack41/src/test/java/org/springframework/integration/xmpp/ignore/OutboundPresenceTests-context.xml
+++ b/spring-integration-xmpp-smack41/src/test/java/org/springframework/integration/xmpp/ignore/OutboundPresenceTests-context.xml
@@ -5,14 +5,14 @@
 			 xmlns:util="http://www.springframework.org/schema/util" xmlns:xmpp="http://www.springframework.org/schema/integration/xmpp"
 			 xmlns:tool="http://www.springframework.org/schema/tool" xmlns:lang="http://www.springframework.org/schema/lang"
 			 xmlns:console="http://www.springframework.org/schema/integration/stream"
-			 xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/tool http://www.springframework.org/schema/tool/spring-tool.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration/xmpp http://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
-		http://www.springframework.org/schema/lang http://www.springframework.org/schema/lang/spring-lang.xsd
-		http://www.springframework.org/schema/integration/stream http://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd">
+			 xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/tool https://www.springframework.org/schema/tool/spring-tool.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration/xmpp https://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/lang https://www.springframework.org/schema/lang/spring-lang.xsd
+		http://www.springframework.org/schema/integration/stream https://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd">
 
 	<beans:bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
 		<beans:property name="location" value="classpath:test.properties"/>

--- a/spring-integration-xmpp-smack41/src/test/java/org/springframework/integration/xmpp/ignore/SmackMessageSampleTest-context.xml
+++ b/spring-integration-xmpp-smack41/src/test/java/org/springframework/integration/xmpp/ignore/SmackMessageSampleTest-context.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/xmpp http://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp.xsd"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/xmpp https://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp.xsd"
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-xmpp="http://www.springframework.org/schema/integration/xmpp">

--- a/spring-integration-xquery/pom.xml
+++ b/spring-integration-xquery/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
 	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
 	<modelVersion>4.0.0</modelVersion>

--- a/spring-integration-xquery/src/test/resources/org/springframework/integration/xquery/config/xml/XQueryRouterParserTests-context.xml
+++ b/spring-integration-xquery/src/test/resources/org/springframework/integration/xquery/config/xml/XQueryRouterParserTests-context.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-xquery="http://www.springframework.org/schema/integration/xquery"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/xquery http://www.springframework.org/schema/integration/xquery/spring-integration-xquery.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/xquery https://www.springframework.org/schema/integration/xquery/spring-integration-xquery.xsd">
 
 	<int-xquery:xquery-router id="xqueryRouterOne" input-channel="xpathRouterOne">
 		<int-xquery:xquery>

--- a/spring-integration-xquery/src/test/resources/org/springframework/integration/xquery/config/xml/XQueryTransformerParserTests-context.xml
+++ b/spring-integration-xquery/src/test/resources/org/springframework/integration/xquery/config/xml/XQueryTransformerParserTests-context.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-xquery="http://www.springframework.org/schema/integration/xquery"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/xquery http://www.springframework.org/schema/integration/xquery/spring-integration-xquery.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/xquery https://www.springframework.org/schema/integration/xquery/spring-integration-xquery.xsd">
 
 	<int:channel id="output"/>
 

--- a/spring-integration-zip/src/test/java/org/springframework/integration/zip/UnZip2FileTests-context.xml
+++ b/spring-integration-zip/src/test/java/org/springframework/integration/zip/UnZip2FileTests-context.xml
@@ -5,11 +5,11 @@
 	xmlns:int-zip="http://www.springframework.org/schema/integration/zip"
 	xmlns:int-file="http://www.springframework.org/schema/integration/file"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/integration/file http://www.springframework.org/schema/integration/file/spring-integration-file.xsd
-		http://www.springframework.org/schema/integration/zip http://www.springframework.org/schema/integration/zip/spring-integration-zip.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/integration/file https://www.springframework.org/schema/integration/file/spring-integration-file.xsd
+		http://www.springframework.org/schema/integration/zip https://www.springframework.org/schema/integration/zip/spring-integration-zip.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd">
 
 	<int:channel id="input"/>
 

--- a/spring-integration-zip/src/test/java/org/springframework/integration/zip/Zip2FileTests-context.xml
+++ b/spring-integration-zip/src/test/java/org/springframework/integration/zip/Zip2FileTests-context.xml
@@ -5,11 +5,11 @@
 	xmlns:int-zip="http://www.springframework.org/schema/integration/zip"
 	xmlns:int-file="http://www.springframework.org/schema/integration/file"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/integration/file http://www.springframework.org/schema/integration/file/spring-integration-file.xsd
-		http://www.springframework.org/schema/integration/zip http://www.springframework.org/schema/integration/zip/spring-integration-zip.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/integration/file https://www.springframework.org/schema/integration/file/spring-integration-file.xsd
+		http://www.springframework.org/schema/integration/zip https://www.springframework.org/schema/integration/zip/spring-integration-zip.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd">
 
 	<int:channel id="input"/>
 

--- a/spring-integration-zip/src/test/java/org/springframework/integration/zip/config/xml/UnZipTransformerParserTests.xml
+++ b/spring-integration-zip/src/test/java/org/springframework/integration/zip/config/xml/UnZipTransformerParserTests.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-zip="http://www.springframework.org/schema/integration/zip"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration/zip http://www.springframework.org/schema/integration/zip/spring-integration-zip.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration/zip https://www.springframework.org/schema/integration/zip/spring-integration-zip.xsd">
 
 	<int:channel id="input"/>
 	<int:channel id="output"/>

--- a/spring-integration-zip/src/test/java/org/springframework/integration/zip/config/xml/ZipTransformerParserTests.xml
+++ b/spring-integration-zip/src/test/java/org/springframework/integration/zip/config/xml/ZipTransformerParserTests.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-zip="http://www.springframework.org/schema/integration/zip"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration/zip http://www.springframework.org/schema/integration/zip/spring-integration-zip.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration/zip https://www.springframework.org/schema/integration/zip/spring-integration-zip.xsd">
 
 	<int:channel id="input"/>
 	<int:channel id="output"/>

--- a/spring-integration-zip/src/test/java/org/springframework/integration/zip/config/xml/ZipTransformerParserTestsWithIncorrectResultType.xml
+++ b/spring-integration-zip/src/test/java/org/springframework/integration/zip/config/xml/ZipTransformerParserTestsWithIncorrectResultType.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-zip="http://www.springframework.org/schema/integration/zip"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration/zip http://www.springframework.org/schema/integration/zip/spring-integration-zip.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration/zip https://www.springframework.org/schema/integration/zip/spring-integration-zip.xsd">
 
 	<int:channel id="input"/>
 	<int:channel id="output"/>

--- a/spring-integration-zip/src/test/java/org/springframework/integration/zip/splitter/UnZipResultSplitterTests-context.xml
+++ b/spring-integration-zip/src/test/java/org/springframework/integration/zip/splitter/UnZipResultSplitterTests-context.xml
@@ -3,9 +3,9 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:int="http://www.springframework.org/schema/integration"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans.xsd
+		https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration
-		http://www.springframework.org/schema/integration/spring-integration.xsd">
+		https://www.springframework.org/schema/integration/spring-integration.xsd">
 
 	<int:channel id="input"/>
 

--- a/spring-integration-zip/src/test/java/org/springframework/integration/zip/transformer/UnZipTransformerTests-context.xml
+++ b/spring-integration-zip/src/test/java/org/springframework/integration/zip/transformer/UnZipTransformerTests-context.xml
@@ -3,8 +3,8 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-zip="http://www.springframework.org/schema/integration/zip"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration/zip http://www.springframework.org/schema/integration/zip/spring-integration-zip.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration/zip https://www.springframework.org/schema/integration/zip/spring-integration-zip.xsd">
 
 </beans>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://opensmpp.logica.com/CommonPart/Introduction/Introduction.htm (301) with 1 occurrences migrated to:  
  https://public.cgi.com/CommonPart/Introduction/Introduction.htm ([https](https://opensmpp.logica.com/CommonPart/Introduction/Introduction.htm) result SSLHandshakeException).
* http://static.springsource.org/spring-integration/reference/htmlsingle/ (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-integration/reference/htmlsingle/ ([https](https://static.springsource.org/spring-integration/reference/htmlsingle/) result 404).
* http://www.puppycrawl.com/dtds/configuration_1_2.dtd (404) with 4 occurrences migrated to:  
  https://www.puppycrawl.com/dtds/configuration_1_2.dtd ([https](https://www.puppycrawl.com/dtds/configuration_1_2.dtd) result 404).
* http://www.puppycrawl.com/dtds/suppressions_1_1.dtd (404) with 4 occurrences migrated to:  
  https://www.puppycrawl.com/dtds/suppressions_1_1.dtd ([https](https://www.puppycrawl.com/dtds/suppressions_1_1.dtd) result 404).
* http://www.springframework.org/schema/integration/aws/spring-integration-aws.xsd (404) with 2 occurrences migrated to:  
  https://www.springframework.org/schema/integration/aws/spring-integration-aws.xsd ([https](https://www.springframework.org/schema/integration/aws/spring-integration-aws.xsd) result 404).
* http://www.springframework.org/schema/integration/cassandra/spring-integration-cassandra.xsd (404) with 2 occurrences migrated to:  
  https://www.springframework.org/schema/integration/cassandra/spring-integration-cassandra.xsd ([https](https://www.springframework.org/schema/integration/cassandra/spring-integration-cassandra.xsd) result 404).
* http://www.springframework.org/schema/integration/hazelcast/spring-integration-hazelcast.xsd (404) with 11 occurrences migrated to:  
  https://www.springframework.org/schema/integration/hazelcast/spring-integration-hazelcast.xsd ([https](https://www.springframework.org/schema/integration/hazelcast/spring-integration-hazelcast.xsd) result 404).
* http://www.springframework.org/schema/integration/jgroups/spring-intergration-jgroups.xsd (404) with 4 occurrences migrated to:  
  https://www.springframework.org/schema/integration/jgroups/spring-intergration-jgroups.xsd ([https](https://www.springframework.org/schema/integration/jgroups/spring-intergration-jgroups.xsd) result 404).
* http://www.springframework.org/schema/integration/print/spring-integration-print.xsd (404) with 2 occurrences migrated to:  
  https://www.springframework.org/schema/integration/print/spring-integration-print.xsd ([https](https://www.springframework.org/schema/integration/print/spring-integration-print.xsd) result 404).
* http://www.springframework.org/schema/integration/smb/spring-integration-smb.xsd (404) with 8 occurrences migrated to:  
  https://www.springframework.org/schema/integration/smb/spring-integration-smb.xsd ([https](https://www.springframework.org/schema/integration/smb/spring-integration-smb.xsd) result 404).
* http://www.springframework.org/schema/integration/smpp/spring-integration-smpp.xsd (404) with 10 occurrences migrated to:  
  https://www.springframework.org/schema/integration/smpp/spring-integration-smpp.xsd ([https](https://www.springframework.org/schema/integration/smpp/spring-integration-smpp.xsd) result 404).
* http://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd (404) with 11 occurrences migrated to:  
  https://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd ([https](https://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd) result 404).
* http://www.springframework.org/schema/integration/twitter/spring-integration-social-twitter.xsd (404) with 11 occurrences migrated to:  
  https://www.springframework.org/schema/integration/twitter/spring-integration-social-twitter.xsd ([https](https://www.springframework.org/schema/integration/twitter/spring-integration-social-twitter.xsd) result 404).
* http://www.springframework.org/schema/integration/voldemort/spring-integration-voldemort.xsd (404) with 5 occurrences migrated to:  
  https://www.springframework.org/schema/integration/voldemort/spring-integration-voldemort.xsd ([https](https://www.springframework.org/schema/integration/voldemort/spring-integration-voldemort.xsd) result 404).
* http://www.springframework.org/schema/integration/xquery/spring-integration-xquery.xsd (404) with 3 occurrences migrated to:  
  https://www.springframework.org/schema/integration/xquery/spring-integration-xquery.xsd ([https](https://www.springframework.org/schema/integration/xquery/spring-integration-xquery.xsd) result 404).
* http://www.springframework.org/schema/integration/zip/spring-integration-zip.xsd (404) with 7 occurrences migrated to:  
  https://www.springframework.org/schema/integration/zip/spring-integration-zip.xsd ([https](https://www.springframework.org/schema/integration/zip/spring-integration-zip.xsd) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://en.wikipedia.org/wiki/Short_Message_Peer-to-Peer with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Short_Message_Peer-to-Peer ([https](https://en.wikipedia.org/wiki/Short_Message_Peer-to-Peer) result 200).
* http://maven.apache.org/xsd/maven-4.0.0.xsd with 8 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* http://www.project-voldemort.com with 1 occurrences migrated to:  
  https://www.project-voldemort.com ([https](https://www.project-voldemort.com) result 200).
* http://www.springframework.org/schema/beans/spring-beans.xsd with 103 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* http://www.springframework.org/schema/context/spring-context-3.1.xsd with 8 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context-3.1.xsd ([https](https://www.springframework.org/schema/context/spring-context-3.1.xsd) result 200).
* http://www.springframework.org/schema/context/spring-context.xsd with 31 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context.xsd ([https](https://www.springframework.org/schema/context/spring-context.xsd) result 200).
* http://www.springframework.org/schema/data/cassandra/spring-cassandra.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/data/cassandra/spring-cassandra.xsd ([https](https://www.springframework.org/schema/data/cassandra/spring-cassandra.xsd) result 200).
* http://www.springframework.org/schema/integration/file/spring-integration-file.xsd with 7 occurrences migrated to:  
  https://www.springframework.org/schema/integration/file/spring-integration-file.xsd ([https](https://www.springframework.org/schema/integration/file/spring-integration-file.xsd) result 200).
* http://www.springframework.org/schema/integration/jdbc/spring-integration-jdbc.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/integration/jdbc/spring-integration-jdbc.xsd ([https](https://www.springframework.org/schema/integration/jdbc/spring-integration-jdbc.xsd) result 200).
* http://www.springframework.org/schema/integration/kafka/spring-integration-kafka.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/integration/kafka/spring-integration-kafka.xsd ([https](https://www.springframework.org/schema/integration/kafka/spring-integration-kafka.xsd) result 200).
* http://www.springframework.org/schema/integration/mail/spring-integration-mail.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/integration/mail/spring-integration-mail.xsd ([https](https://www.springframework.org/schema/integration/mail/spring-integration-mail.xsd) result 200).
* http://www.springframework.org/schema/integration/spring-integration-2.2.xsd with 4 occurrences migrated to:  
  https://www.springframework.org/schema/integration/spring-integration-2.2.xsd ([https](https://www.springframework.org/schema/integration/spring-integration-2.2.xsd) result 200).
* http://www.springframework.org/schema/integration/spring-integration.xsd with 92 occurrences migrated to:  
  https://www.springframework.org/schema/integration/spring-integration.xsd ([https](https://www.springframework.org/schema/integration/spring-integration.xsd) result 200).
* http://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd with 16 occurrences migrated to:  
  https://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd ([https](https://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd) result 200).
* http://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp.xsd with 14 occurrences migrated to:  
  https://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp.xsd ([https](https://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp.xsd) result 200).
* http://www.springframework.org/schema/jdbc/spring-jdbc.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/jdbc/spring-jdbc.xsd ([https](https://www.springframework.org/schema/jdbc/spring-jdbc.xsd) result 200).
* http://www.springframework.org/schema/lang/spring-lang.xsd with 5 occurrences migrated to:  
  https://www.springframework.org/schema/lang/spring-lang.xsd ([https](https://www.springframework.org/schema/lang/spring-lang.xsd) result 200).
* http://www.springframework.org/schema/task/spring-task.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/task/spring-task.xsd ([https](https://www.springframework.org/schema/task/spring-task.xsd) result 200).
* http://www.springframework.org/schema/tool/spring-tool.xsd with 5 occurrences migrated to:  
  https://www.springframework.org/schema/tool/spring-tool.xsd ([https](https://www.springframework.org/schema/tool/spring-tool.xsd) result 200).
* http://www.springframework.org/schema/util/spring-util.xsd with 8 occurrences migrated to:  
  https://www.springframework.org/schema/util/spring-util.xsd ([https](https://www.springframework.org/schema/util/spring-util.xsd) result 200).
* http://code.google.com/p/jsmpp/ with 1 occurrences migrated to:  
  https://code.google.com/p/jsmpp/ ([https](https://code.google.com/p/jsmpp/) result 301).
* http://www.eaipatterns.com/MessagingGateway.html (302) with 1 occurrences migrated to:  
  https://www.enterpriseintegrationpatterns.com/MessagingGateway.html ([https](https://www.eaipatterns.com/MessagingGateway.html) result 301).
* http://www.springsource.org with 6 occurrences migrated to:  
  https://www.springsource.org ([https](https://www.springsource.org) result 301).
* http://www.springsource.org/spring-integration with 3 occurrences migrated to:  
  https://www.springsource.org/spring-integration ([https](https://www.springsource.org/spring-integration) result 301).

# Ignored
These URLs were intentionally ignored.

* http://docbook.org/ns/docbook with 15 occurrences
* http://jakarta.apache.org/log4j/ with 7 occurrences
* http://maven.apache.org/POM/4.0.0 with 16 occurrences
* http://www.springframework.org/schema/beans with 206 occurrences
* http://www.springframework.org/schema/context with 79 occurrences
* http://www.springframework.org/schema/data/cassandra with 2 occurrences
* http://www.springframework.org/schema/integration with 192 occurrences
* http://www.springframework.org/schema/integration/aws with 4 occurrences
* http://www.springframework.org/schema/integration/cassandra with 4 occurrences
* http://www.springframework.org/schema/integration/file with 14 occurrences
* http://www.springframework.org/schema/integration/hazelcast with 22 occurrences
* http://www.springframework.org/schema/integration/jdbc with 2 occurrences
* http://www.springframework.org/schema/integration/jgroups with 8 occurrences
* http://www.springframework.org/schema/integration/kafka with 4 occurrences
* http://www.springframework.org/schema/integration/mail with 4 occurrences
* http://www.springframework.org/schema/integration/print with 4 occurrences
* http://www.springframework.org/schema/integration/smb with 16 occurrences
* http://www.springframework.org/schema/integration/smpp with 20 occurrences
* http://www.springframework.org/schema/integration/splunk with 22 occurrences
* http://www.springframework.org/schema/integration/stream with 32 occurrences
* http://www.springframework.org/schema/integration/twitter with 22 occurrences
* http://www.springframework.org/schema/integration/voldemort with 10 occurrences
* http://www.springframework.org/schema/integration/xmpp with 28 occurrences
* http://www.springframework.org/schema/integration/xquery with 6 occurrences
* http://www.springframework.org/schema/integration/zip with 14 occurrences
* http://www.springframework.org/schema/jdbc with 2 occurrences
* http://www.springframework.org/schema/lang with 10 occurrences
* http://www.springframework.org/schema/p with 7 occurrences
* http://www.springframework.org/schema/task with 2 occurrences
* http://www.springframework.org/schema/tool with 10 occurrences
* http://www.springframework.org/schema/util with 16 occurrences
* http://www.w3.org/1999/xlink with 15 occurrences
* http://www.w3.org/2001/XInclude with 9 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 111 occurrences