### PR TITLE
Updated jCIFS library to the latest version to support SMB2/SMB3

### DIFF
--- a/spring-integration-smb/README.md
+++ b/spring-integration-smb/README.md
@@ -1,4 +1,4 @@
-Spring Integration Smb Support
+Spring Integration SMB Support
 ==============================
 
 ## Introduction
@@ -7,3 +7,54 @@ This module add Spring Integration support for [Server Message Block][] (SMB).
 
 [Server Message Block]: https://en.wikipedia.org/wiki/Server_Message_Block
 
+## Version
+
+[Versions in Maven Repository](http://central.maven.org/maven2/org/springframework/integration/spring-integration-smb/)
+
+## Using Maven
+
+Put the following block into pom.xml if using Maven:
+
+    <dependency>
+        <groupId>org.springframework.integration</groupId>
+        <artifactId>spring-integration-smb</artifactId>
+        <version>1.0.0.RELEASE</version>
+    </dependency>
+
+## Changes
+
+ * Updated to use the latest version of the [JCIFS](https://github.com/codelibs/jcifs) library
+ * SMB2 (2.02 protocol level) support, some SMB3 support
+
+## Overview
+
+The Java CIFS Client Library has been chosen as a Java implementation for the CIFS/SMB networking protocol.
+Its `SmbFile` abstraction is simply wrapped to the Spring Integration "Remote File" foundations like `SmbSession`, `SmbRemoteFileTemplate`, etc.
+
+The SMB Channel Adapters and support classes implementations are fully similar to existing components for (S)FTP or AWS S3 protocols.
+So, if you familiar with those components, it is pretty straightforward to use this extension. But any way here are several words about existing components:
+
+### SMB Inbound Channel Adapter
+
+To download SMB files locally the `SmbInboundFileSynchronizingMessageSource` is provided.
+It is simple extension of the `AbstractInboundFileSynchronizingMessageSource` which requires `SmbInboundFileSynchronizer` injection.
+For filtering remote files you still can use any existing `FileListFilter` implementations, but particular `SmbRegexPatternFileListFilter` and `SmbSimplePatternFileListFilter` are provided.
+For XML configuration the `<int-smb:inbound-channel-adapter>` component is provided.
+
+### SMB Outbound Channel Adapter
+
+There is no (yet) some SMB specific requirements for files transferring to SMB, so for XML `<int-smb:outbound-channel-adapter>` component we simply reuse an existing `FileTransferringMessageHandler`.
+In case of Java configuration that `FileTransferringMessageHandler` should be supplied with the `SmbSessionFactory` (or `SmbRemoteFileTemplate`).
+
+    @ServiceActivator(inputChannel = "storeToSmb")
+    @Bean
+    public MessageHandler smbMessageHandler(SmbSessionFactory smbSessionFactory) {
+        FileTransferringMessageHandler<SmbFile> handler =
+                    new FileTransferringMessageHandler<>(smbSessionFactory);
+        handler.setRemoteDirectoryExpression(
+                    new LiteralExpression("remote-target-dir"));
+        handler.setFileNameGenerator(m ->
+                    m.getHeaders().get(FileHeaders.FILENAME, String.class) + ".test");
+        handler.setAutoCreateDirectory(true);
+        return handler;
+    }

--- a/spring-integration-smb/build.gradle
+++ b/spring-integration-smb/build.gradle
@@ -56,7 +56,7 @@ compileTestJava {
 ext {
 	idPrefix = 'smb'
 
-	jcifsVersion = '1.3.18.3'
+	jcifsVersion = '2.1.7'
 	log4jVersion = '2.11.0'
 	springIntegrationVersion = '5.0.13.BUILD-SNAPSHOT'
 

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbSession.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbSession.java
@@ -63,10 +63,6 @@ public class SmbSession implements Session<SmbFile> {
 
 	private static final String SMB_FILE_SEPARATOR = "/";
 
-	static {
-		configureJcifs();
-	}
-
 	private final SmbShare smbShare;
 
 	/**
@@ -458,7 +454,7 @@ public class SmbSession implements Session<SmbFile> {
 			return this.smbShare;
 		}
 
-		SmbFile smbFile = new SmbFile(this.smbShare, cleanedPath, SmbFile.FILE_SHARE_READ);
+		SmbFile smbFile = new SmbFile(this.smbShare, cleanedPath);
 
 		boolean appendFileSeparator = !cleanedPath.endsWith(SMB_FILE_SEPARATOR);
 		if (appendFileSeparator) {
@@ -496,32 +492,6 @@ public class SmbSession implements Session<SmbFile> {
 	 */
 	public SmbFile createSmbDirectoryObject(String _path) throws IOException {
 		return createSmbFileObject(_path, true);
-	}
-
-	/**
-	 * Static configuration of the JCIFS library.
-	 * The log level of this class is mapped to a suitable <code>jcifs.util.loglevel</code>
-	 */
-	static void configureJcifs() {
-		// TODO jcifs.Config.setProperty("jcifs.smb.client.useExtendedSecurity", "false");
-		// TODO jcifs.Config.setProperty("jcifs.smb.client.disablePlainTextPasswords", "false");
-
-		// set JCIFS SMB client library' log level unless already configured by system property
-		final String sysPropLogLevel = "jcifs.util.loglevel";
-
-		if (jcifs.Config.getProperty(sysPropLogLevel) == null) {
-			// set log level according to this class' logger's log level.
-			Log log = LogFactory.getLog(SmbSession.class);
-			if (log.isTraceEnabled()) {
-				jcifs.Config.setProperty(sysPropLogLevel, "N");
-			}
-			else if (log.isDebugEnabled()) {
-				jcifs.Config.setProperty(sysPropLogLevel, "3");
-			}
-			else {
-				jcifs.Config.setProperty(sysPropLogLevel, "1");
-			}
-		}
 	}
 
 	@Override

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbShare.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbShare.java
@@ -26,6 +26,8 @@ import org.springframework.core.NestedIOException;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
+import jcifs.context.SingletonContext;
+import jcifs.smb.NtlmPasswordAuthenticator;
 import jcifs.smb.SmbException;
 import jcifs.smb.SmbFile;
 
@@ -43,12 +45,20 @@ public class SmbShare extends SmbFile {
 
 	private final AtomicBoolean useTempFile = new AtomicBoolean(false);
 
+	/**
+	 * @deprecated as of release 1.1.0, use {@link #SmbShare(SmbConfig)} instead.
+	 * @param url do not use
+	 * @throws IOException do not use
+	 */
+	@Deprecated
 	public SmbShare(String url) throws IOException {
 		super(StringUtils.cleanPath(url));
 	}
 
 	public SmbShare(SmbConfig _smbConfig) throws IOException {
-		this(_smbConfig.validate().getUrl());
+		super(StringUtils.cleanPath(_smbConfig.validate().getUrl()),
+				SingletonContext.getInstance().withCredentials(new NtlmPasswordAuthenticator(
+						_smbConfig.getDomain(), _smbConfig.getUsername(), _smbConfig.getPassword())));
 	}
 
 	public void init() throws NestedIOException {

--- a/spring-integration-smb/src/test/java/org/springframework/integration/smb/session/SmbSessionTests.java
+++ b/spring-integration-smb/src/test/java/org/springframework/integration/smb/session/SmbSessionTests.java
@@ -27,81 +27,110 @@ import jcifs.smb.SmbFile;
 /**
  *
  * @author Gunnar Hillert
+ * @author Gregory Bragg - 2019/04/09 - All tests rewritten during the upgrade to the latest version of jCIFS
  *
  */
 public class SmbSessionTests {
 
 	@Test
 	public void testCreateSmbFileObjectWithBackSlash1() throws IOException {
-
 		System.setProperty("file.separator", "\\");
-		SmbShare smbShare = new SmbShare("smb://myshare/shared/");
+		SmbConfig config = new SmbConfig();
+		config.setHost("myshare");
+		config.setPort(445);
+		config.setShareAndDir("shared/");
+		SmbShare smbShare = new SmbShare(config);
 		SmbSession smbSession = new SmbSession(smbShare);
+
 		SmbFile smbFile = smbSession.createSmbFileObject("smb://myshare\\blubba\\");
 		assertEquals("smb://myshare/blubba/", smbFile.getPath());
+		smbSession.close();
 	}
 
 	@Test
 	public void testCreateSmbFileObjectWithBackSlash2() throws IOException {
-
 		System.setProperty("file.separator", "\\");
-		SmbShare smbShare = new SmbShare("smb://myshare\\shared\\");
+		SmbConfig config = new SmbConfig();
+		config.setHost("myshare");
+		config.setPort(445);
+		config.setShareAndDir("shared\\");
+		SmbShare smbShare = new SmbShare(config);
 		SmbSession smbSession = new SmbSession(smbShare);
+
 		SmbFile smbFile = smbSession.createSmbFileObject("smb://myshare\\blubba\\");
 		assertEquals("smb://myshare/blubba/", smbFile.getPath());
+		smbSession.close();
 	}
 
 	@Test
 	public void testCreateSmbFileObjectWithBackSlash3() throws IOException {
-
 		System.setProperty("file.separator", "\\");
-		SmbShare smbShare = new SmbShare("smb://myshare\\shared\\");
+		SmbConfig config = new SmbConfig();
+		config.setHost("myshare");
+		config.setPort(445);
+		config.setShareAndDir("shared\\");
+		SmbShare smbShare = new SmbShare(config);
 		SmbSession smbSession = new SmbSession(smbShare);
+
 		SmbFile smbFile = smbSession.createSmbFileObject("..\\another");
-		assertEquals("smb://myshare/another", smbFile.getPath());
+		assertEquals("smb://myshare:445/another", smbFile.getPath());
+		smbSession.close();
 	}
 
 	@Test
 	public void testCreateSmbFileObjectWithBackSlash4() throws IOException {
-
 		System.setProperty("file.separator", "/");
-		SmbShare smbShare = new SmbShare("smb://myshare/shared/");
+		SmbConfig config = new SmbConfig();
+		config.setHost("myshare");
+		config.setPort(445);
+		config.setShareAndDir("shared/");
+		SmbShare smbShare = new SmbShare(config);
 		SmbSession smbSession = new SmbSession(smbShare);
+
 		SmbFile smbFile = smbSession.createSmbFileObject("smb://myshare\\blubba\\");
 		assertEquals("smb://myshare/blubba/", smbFile.getPath());
+		smbSession.close();
 	}
-
 
 	@Test
 	public void testCreateSmbFileObjectwithMissingTrailingSlash1() throws IOException {
-
-		SmbShare smbShare = new SmbShare("smb://myshare/shared");
+		SmbConfig config = new SmbConfig();
+		config.setHost("myshare");
+		config.setPort(445);
+		config.setShareAndDir("shared");
+		SmbShare smbShare = new SmbShare(config);
 		SmbSession smbSession = new SmbSession(smbShare);
 
 		SmbFile smbFile = smbSession.createSmbFileObject("smb://myshare\\blubba");
 		assertEquals("smb://myshare/blubba", smbFile.getPath());
-
+		smbSession.close();
 	}
 
 	@Test
 	public void testCreateSmbFileObjectwithMissingTrailingSlash2() throws IOException {
-
-		SmbShare smbShare = new SmbShare("smb://myshare/shared/");
+		SmbConfig config = new SmbConfig();
+		config.setHost("myshare");
+		config.setPort(445);
+		config.setShareAndDir("shared/");
+		SmbShare smbShare = new SmbShare(config);
 		SmbSession smbSession = new SmbSession(smbShare);
 
 		SmbFile smbFile = smbSession.createSmbFileObject(".");
-		assertEquals("smb://myshare/shared/", smbFile.getPath());
-
+		assertEquals("smb://myshare:445/shared/", smbFile.getPath());
+		smbSession.close();
 	}
 
 	@Test
 	public void testCreateSmbFileObjectwithMissingTrailingSlash3() throws IOException {
-
-		SmbShare smbShare = new SmbShare("smb://myshare/shared/");
+		SmbConfig config = new SmbConfig();
+		config.setHost("myshare");
+		config.setPort(445);
+		config.setShareAndDir("shared/");
+		SmbShare smbShare = new SmbShare(config);
 		SmbSession smbSession = new SmbSession(smbShare);
 
 		SmbFile smbFile = smbSession.createSmbFileObject("../anotherShare");
-		assertEquals("smb://myshare/anotherShare", smbFile.getPath());
-
+		assertEquals("smb://myshare:445/anotherShare", smbFile.getPath());
+		smbSession.close();
 	}
 }

--- a/spring-integration-smb/src/test/java/org/springframework/integration/smb/session/SmbSessionTests.java
+++ b/spring-integration-smb/src/test/java/org/springframework/integration/smb/session/SmbSessionTests.java
@@ -38,7 +38,7 @@ public class SmbSessionTests {
 		SmbShare smbShare = new SmbShare("smb://myshare/shared/");
 		SmbSession smbSession = new SmbSession(smbShare);
 		SmbFile smbFile = smbSession.createSmbFileObject("smb://myshare\\blubba\\");
-		assertEquals("smb://myshare/shared/smb://myshare/blubba/", smbFile.getCanonicalPath());
+		assertEquals("smb://myshare/blubba/", smbFile.getPath());
 	}
 
 	@Test
@@ -48,7 +48,7 @@ public class SmbSessionTests {
 		SmbShare smbShare = new SmbShare("smb://myshare\\shared\\");
 		SmbSession smbSession = new SmbSession(smbShare);
 		SmbFile smbFile = smbSession.createSmbFileObject("smb://myshare\\blubba\\");
-		assertEquals("smb://myshare/shared/smb://myshare/blubba/", smbFile.getCanonicalPath());
+		assertEquals("smb://myshare/blubba/", smbFile.getPath());
 	}
 
 	@Test
@@ -58,7 +58,7 @@ public class SmbSessionTests {
 		SmbShare smbShare = new SmbShare("smb://myshare\\shared\\");
 		SmbSession smbSession = new SmbSession(smbShare);
 		SmbFile smbFile = smbSession.createSmbFileObject("..\\another");
-		assertEquals("smb://myshare/shared/../another", smbFile.getCanonicalPath());
+		assertEquals("smb://myshare/another", smbFile.getPath());
 	}
 
 	@Test
@@ -68,7 +68,7 @@ public class SmbSessionTests {
 		SmbShare smbShare = new SmbShare("smb://myshare/shared/");
 		SmbSession smbSession = new SmbSession(smbShare);
 		SmbFile smbFile = smbSession.createSmbFileObject("smb://myshare\\blubba\\");
-		assertEquals("smb://myshare/shared/smb://myshare/blubba/", smbFile.getCanonicalPath());
+		assertEquals("smb://myshare/blubba/", smbFile.getPath());
 	}
 
 
@@ -79,7 +79,7 @@ public class SmbSessionTests {
 		SmbSession smbSession = new SmbSession(smbShare);
 
 		SmbFile smbFile = smbSession.createSmbFileObject("smb://myshare\\blubba");
-		assertEquals("smb://myshare/sharedsmb://myshare/blubba", smbFile.getCanonicalPath());
+		assertEquals("smb://myshare/blubba", smbFile.getPath());
 
 	}
 
@@ -90,7 +90,7 @@ public class SmbSessionTests {
 		SmbSession smbSession = new SmbSession(smbShare);
 
 		SmbFile smbFile = smbSession.createSmbFileObject(".");
-		assertEquals("smb://myshare/shared/", smbFile.getCanonicalPath());
+		assertEquals("smb://myshare/shared/", smbFile.getPath());
 
 	}
 
@@ -101,7 +101,7 @@ public class SmbSessionTests {
 		SmbSession smbSession = new SmbSession(smbShare);
 
 		SmbFile smbFile = smbSession.createSmbFileObject("../anotherShare");
-		assertEquals("smb://myshare/shared/../anotherShare", smbFile.getCanonicalPath());
+		assertEquals("smb://myshare/anotherShare", smbFile.getPath());
 
 	}
 }

--- a/spring-integration-smb/src/test/java/org/springframework/integration/smb/session/SmbSessionTests.java
+++ b/spring-integration-smb/src/test/java/org/springframework/integration/smb/session/SmbSessionTests.java
@@ -38,7 +38,7 @@ public class SmbSessionTests {
 		SmbShare smbShare = new SmbShare("smb://myshare/shared/");
 		SmbSession smbSession = new SmbSession(smbShare);
 		SmbFile smbFile = smbSession.createSmbFileObject("smb://myshare\\blubba\\");
-		assertEquals("smb://myshare/blubba/", smbFile.getCanonicalPath());
+		assertEquals("smb://myshare/shared/smb://myshare/blubba/", smbFile.getCanonicalPath());
 	}
 
 	@Test
@@ -48,7 +48,7 @@ public class SmbSessionTests {
 		SmbShare smbShare = new SmbShare("smb://myshare\\shared\\");
 		SmbSession smbSession = new SmbSession(smbShare);
 		SmbFile smbFile = smbSession.createSmbFileObject("smb://myshare\\blubba\\");
-		assertEquals("smb://myshare/blubba/", smbFile.getCanonicalPath());
+		assertEquals("smb://myshare/shared/smb://myshare/blubba/", smbFile.getCanonicalPath());
 	}
 
 	@Test
@@ -58,7 +58,7 @@ public class SmbSessionTests {
 		SmbShare smbShare = new SmbShare("smb://myshare\\shared\\");
 		SmbSession smbSession = new SmbSession(smbShare);
 		SmbFile smbFile = smbSession.createSmbFileObject("..\\another");
-		assertEquals("smb://myshare/another/", smbFile.getCanonicalPath());
+		assertEquals("smb://myshare/shared/../another", smbFile.getCanonicalPath());
 	}
 
 	@Test
@@ -68,7 +68,7 @@ public class SmbSessionTests {
 		SmbShare smbShare = new SmbShare("smb://myshare/shared/");
 		SmbSession smbSession = new SmbSession(smbShare);
 		SmbFile smbFile = smbSession.createSmbFileObject("smb://myshare\\blubba\\");
-		assertEquals("smb://myshare/blubba/", smbFile.getCanonicalPath());
+		assertEquals("smb://myshare/shared/smb://myshare/blubba/", smbFile.getCanonicalPath());
 	}
 
 
@@ -79,7 +79,7 @@ public class SmbSessionTests {
 		SmbSession smbSession = new SmbSession(smbShare);
 
 		SmbFile smbFile = smbSession.createSmbFileObject("smb://myshare\\blubba");
-		assertEquals("smb://myshare/blubba/", smbFile.getCanonicalPath());
+		assertEquals("smb://myshare/sharedsmb://myshare/blubba", smbFile.getCanonicalPath());
 
 	}
 
@@ -101,7 +101,7 @@ public class SmbSessionTests {
 		SmbSession smbSession = new SmbSession(smbShare);
 
 		SmbFile smbFile = smbSession.createSmbFileObject("../anotherShare");
-		assertEquals("smb://myshare/anotherShare/", smbFile.getCanonicalPath());
+		assertEquals("smb://myshare/shared/../anotherShare", smbFile.getCanonicalPath());
 
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration-extensions/issues/206

Updated dependent jCIFS library to support SMB2 and SMB3 protocols since SMB1 is no longer supported by the latest versions of Windows servers as it was deemed a security risk by Microsoft. SMB1 has been deprecated.
