### PR TITLE
GH-208 Enhancement to allow setting of SMB min/max versions

### DIFF
--- a/spring-integration-smb/README.md
+++ b/spring-integration-smb/README.md
@@ -3,7 +3,7 @@ Spring Integration SMB Support
 
 ## Introduction
 
-This module add Spring Integration support for [Server Message Block][] (SMB).
+This module adds Spring Integration support for [Server Message Block][] (SMB).
 
 [Server Message Block]: https://en.wikipedia.org/wiki/Server_Message_Block
 
@@ -23,8 +23,12 @@ Put the following block into pom.xml if using Maven:
 
 ## Changes
 
+##### Version 1.1
  * Updated to use the latest version of the [JCIFS](https://github.com/codelibs/jcifs) library
  * SMB2 (2.02 protocol level) support, some SMB3 support
+
+##### Version 1.2
+ * Ability to set the SMB min/max versions in the `SmbSessionFactory` via configuration in the JCIFS library
 
 ## Overview
 

--- a/spring-integration-smb/README.md
+++ b/spring-integration-smb/README.md
@@ -50,33 +50,37 @@ For XML configuration the `<int-smb:inbound-channel-adapter>` component is provi
 There is no (yet) some SMB specific requirements for files transferring to SMB, so for XML `<int-smb:outbound-channel-adapter>` component we simply reuse an existing `FileTransferringMessageHandler`.
 In case of Java configuration that `FileTransferringMessageHandler` should be supplied with the `SmbSessionFactory` (or `SmbRemoteFileTemplate`).
 
-    @ServiceActivator(inputChannel = "storeToSmb")
-    @Bean
-    public MessageHandler smbMessageHandler(SmbSessionFactory smbSessionFactory) {
-        FileTransferringMessageHandler<SmbFile> handler =
-                    new FileTransferringMessageHandler<>(smbSessionFactory);
-        handler.setRemoteDirectoryExpression(
-                    new LiteralExpression("remote-target-dir"));
-        handler.setFileNameGenerator(m ->
-                    m.getHeaders().get(FileHeaders.FILENAME, String.class) + ".test");
-        handler.setAutoCreateDirectory(true);
-        return handler;
-    }
+````java
+@ServiceActivator(inputChannel = "storeToSmb")
+@Bean
+public MessageHandler smbMessageHandler(SmbSessionFactory smbSessionFactory) {
+    FileTransferringMessageHandler<SmbFile> handler =
+                new FileTransferringMessageHandler<>(smbSessionFactory);
+    handler.setRemoteDirectoryExpression(
+                new LiteralExpression("remote-target-dir"));
+    handler.setFileNameGenerator(m ->
+                m.getHeaders().get(FileHeaders.FILENAME, String.class) + ".test");
+    handler.setAutoCreateDirectory(true);
+    return handler;
+}
+````
 
 ### Setting SMB Protocol Min/Max Versions
 
 Example: To set a minimum version of SMB 2.1 and a maximum version of SMB 3.1.1
 
-    @Bean
-    public SmbSessionFactory smbSessionFactory() {
-        SmbSessionFactory smbSession = new SmbSessionFactory();
-        smbSession.setHost(myHost);
-        smbSession.setPort(myPort);
-        smbSession.setDomain(myDomain);
-        smbSession.setUsername(myUser);
-        smbSession.setPassword(myPassword);
-        smbSession.setShareAndDir(myShareAndDir);
-        smbSession.setSmbMinVer(DialectVersion.SMB210);
-        smbSession.setSmbMaxVer(DialectVersion.SMB311);
-        return smbSession;
-    }
+````java
+@Bean
+public SmbSessionFactory smbSessionFactory() {
+    SmbSessionFactory smbSession = new SmbSessionFactory();
+    smbSession.setHost("myHost");
+    smbSession.setPort(445);
+    smbSession.setDomain("myDomain");
+    smbSession.setUsername("myUser");
+    smbSession.setPassword("myPassword");
+    smbSession.setShareAndDir("myShareAndDir");
+    smbSession.setSmbMinVer(DialectVersion.SMB210);
+    smbSession.setSmbMaxVer(DialectVersion.SMB311);
+    return smbSession;
+}
+````

--- a/spring-integration-smb/README.md
+++ b/spring-integration-smb/README.md
@@ -62,3 +62,21 @@ In case of Java configuration that `FileTransferringMessageHandler` should be su
         handler.setAutoCreateDirectory(true);
         return handler;
     }
+
+### Setting SMB Protocol Min/Max Versions
+
+Example: To set a minimum version of SMB 2.1 and a maximum version of SMB 3.1.1
+
+    @Bean
+    public SmbSessionFactory smbSessionFactory() {
+        SmbSessionFactory smbSession = new SmbSessionFactory();
+        smbSession.setHost(myHost);
+        smbSession.setPort(myPort);
+        smbSession.setDomain(myDomain);
+        smbSession.setUsername(myUser);
+        smbSession.setPassword(myPassword);
+        smbSession.setShareAndDir(myShareAndDir);
+        smbSession.setSmbMinVer(DialectVersion.SMB210);
+        smbSession.setSmbMaxVer(DialectVersion.SMB311);
+        return smbSession;
+    }

--- a/spring-integration-smb/README.md
+++ b/spring-integration-smb/README.md
@@ -79,8 +79,8 @@ public SmbSessionFactory smbSessionFactory() {
     smbSession.setUsername("myUser");
     smbSession.setPassword("myPassword");
     smbSession.setShareAndDir("myShareAndDir");
-    smbSession.setSmbMinVer(DialectVersion.SMB210);
-    smbSession.setSmbMaxVer(DialectVersion.SMB311);
+    smbSession.setSmbMinVersion(DialectVersion.SMB210);
+    smbSession.setSmbMaxVersion(DialectVersion.SMB311);
     return smbSession;
 }
 ````

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbConfig.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbConfig.java
@@ -57,13 +57,13 @@ public class SmbConfig {
 	 * Defaults to and follows the jCIFS library default of 'SMB1'
 	 * @since 1.2
 	 */
-	private DialectVersion smbMinVer = DialectVersion.SMB1;
+	private DialectVersion smbMinVersion = DialectVersion.SMB1;
 
 	/**
 	 * Defaults to and follows the jCIFS library default of 'SMB210'
 	 * @since 1.2
 	 */
-	private DialectVersion smbMaxVer = DialectVersion.SMB210;
+	private DialectVersion smbMaxVersion = DialectVersion.SMB210;
 
 	public SmbConfig() {
 	}
@@ -150,45 +150,41 @@ public class SmbConfig {
 	/**
 	 * Gets the desired minimum SMB version value for what the Windows server will allow
 	 * during protocol transport negotiation.
-	 *
 	 * @return one of SMB1, SMB202, SMB210, SMB300, SMB302 or SMB311
 	 * @since 1.2
 	 */
-	public DialectVersion getSmbMinVer() {
-		return this.smbMinVer;
+	public DialectVersion getSmbMinVersion() {
+		return this.smbMinVersion;
 	}
 
 	/**
 	 * Sets the desired minimum SMB version value for what the Windows server will allow
 	 * during protocol transport negotiation.
-	 *
-	 * @param _smbMinVer one of SMB1, SMB202, SMB210, SMB300, SMB302 or SMB311
+	 * @param _smbMinVersion one of SMB1, SMB202, SMB210, SMB300, SMB302 or SMB311
 	 * @since 1.2
 	 */
-	public void setSmbMinVer(DialectVersion _smbMinVer) {
-		this.smbMinVer = _smbMinVer;
+	public void setSmbMinVersion(DialectVersion _smbMinVersion) {
+		this.smbMinVersion = _smbMinVersion;
 	}
 
 	/**
 	 * Gets the desired maximum SMB version value for what the Windows server will allow
 	 * during protocol transport negotiation.
-	 *
 	 * @return one of SMB1, SMB202, SMB210, SMB300, SMB302 or SMB311
 	 * @since 1.2
 	 */
-	public DialectVersion getSmbMaxVer() {
-		return this.smbMaxVer;
+	public DialectVersion getSmbMaxVersion() {
+		return this.smbMaxVersion;
 	}
 
 	/**
 	 * Sets the desired maximum SMB version value for what the Windows server will allow
 	 * during protocol transport negotiation.
-	 *
-	 * @param _smbMaxVer one of SMB1, SMB202, SMB210, SMB300, SMB302 or SMB311
+	 * @param _smbMaxVersion one of SMB1, SMB202, SMB210, SMB300, SMB302 or SMB311
 	 * @since 1.2
 	 */
-	public void setSmbMaxVer(DialectVersion _smbMaxVer) {
-		this.smbMaxVer = _smbMaxVer;
+	public void setSmbMaxVersion(DialectVersion _smbMaxVersion) {
+		this.smbMaxVersion = _smbMaxVersion;
 	}
 
 	String getDomainUserPass(boolean _includePassword) {

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbConfig.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2018 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@ import java.net.URISyntaxException;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
+import jcifs.DialectVersion;
+
 /**
  * Data holder class for a SMB share configuration.
  *
@@ -31,8 +33,7 @@ import org.springframework.util.StringUtils;
  * @author Markus Spann
  * @author Prafull Kumar Soni
  * @author Artem Bilan
- *
- * @since 1.0
+ * @author Gregory Bragg
  */
 public class SmbConfig {
 
@@ -51,6 +52,12 @@ public class SmbConfig {
 	private boolean replaceFile = false;
 
 	private boolean useTempFile = false;
+
+	/** follows jCIFS library defaults */
+	private DialectVersion smbMinVer = DialectVersion.SMB1;
+
+	/** follows jCIFS library defaults */
+	private DialectVersion smbMaxVer = DialectVersion.SMB210;
 
 	public SmbConfig() {
 	}
@@ -132,6 +139,22 @@ public class SmbConfig {
 
 	public boolean isUseTempFile() {
 		return this.useTempFile;
+	}
+
+	public DialectVersion getSmbMinVer() {
+		return this.smbMinVer;
+	}
+
+	public void setSmbMinVer(DialectVersion smbMinVer) {
+		this.smbMinVer = smbMinVer;
+	}
+
+	public DialectVersion getSmbMaxVer() {
+		return this.smbMaxVer;
+	}
+
+	public void setSmbMaxVer(DialectVersion smbMaxVer) {
+		this.smbMaxVer = smbMaxVer;
 	}
 
 	String getDomainUserPass(boolean _includePassword) {

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbConfig.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbConfig.java
@@ -165,8 +165,8 @@ public class SmbConfig {
 	 * @param smbMinVer one of SMB1, SMB202, SMB210, SMB300, SMB302 or SMB311
 	 * @since 1.2
 	 */
-	public void setSmbMinVer(DialectVersion smbMinVer) {
-		this.smbMinVer = smbMinVer;
+	public void setSmbMinVer(DialectVersion _smbMinVer) {
+		this.smbMinVer = _smbMinVer;
 	}
 
 	/**
@@ -187,8 +187,8 @@ public class SmbConfig {
 	 * @param smbMaxVer one of SMB1, SMB202, SMB210, SMB300, SMB302 or SMB311
 	 * @since 1.2
 	 */
-	public void setSmbMaxVer(DialectVersion smbMaxVer) {
-		this.smbMaxVer = smbMaxVer;
+	public void setSmbMaxVer(DialectVersion _smbMaxVer) {
+		this.smbMaxVer = _smbMaxVer;
 	}
 
 	String getDomainUserPass(boolean _includePassword) {

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbConfig.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbConfig.java
@@ -53,10 +53,16 @@ public class SmbConfig {
 
 	private boolean useTempFile = false;
 
-	/** follows jCIFS library defaults */
+	/**
+	 * Defaults to and follows the jCIFS library default of 'SMB1'
+	 * @since 1.2
+	 */
 	private DialectVersion smbMinVer = DialectVersion.SMB1;
 
-	/** follows jCIFS library defaults */
+	/**
+	 * Defaults to and follows the jCIFS library default of 'SMB210'
+	 * @since 1.2
+	 */
 	private DialectVersion smbMaxVer = DialectVersion.SMB210;
 
 	public SmbConfig() {
@@ -141,18 +147,46 @@ public class SmbConfig {
 		return this.useTempFile;
 	}
 
+	/**
+	 * Gets the desired minimum SMB version value for what the Windows server will allow
+	 * during protocol transport negotiation.
+	 *
+	 * @return one of SMB1, SMB202, SMB210, SMB300, SMB302 or SMB311
+	 * @since 1.2
+	 */
 	public DialectVersion getSmbMinVer() {
 		return this.smbMinVer;
 	}
 
+	/**
+	 * Sets the desired minimum SMB version value for what the Windows server will allow
+	 * during protocol transport negotiation.
+	 *
+	 * @param smbMinVer one of SMB1, SMB202, SMB210, SMB300, SMB302 or SMB311
+	 * @since 1.2
+	 */
 	public void setSmbMinVer(DialectVersion smbMinVer) {
 		this.smbMinVer = smbMinVer;
 	}
 
+	/**
+	 * Gets the desired maximum SMB version value for what the Windows server will allow
+	 * during protocol transport negotiation.
+	 *
+	 * @return one of SMB1, SMB202, SMB210, SMB300, SMB302 or SMB311
+	 * @since 1.2
+	 */
 	public DialectVersion getSmbMaxVer() {
 		return this.smbMaxVer;
 	}
 
+	/**
+	 * Sets the desired maximum SMB version value for what the Windows server will allow
+	 * during protocol transport negotiation.
+	 *
+	 * @param smbMaxVer one of SMB1, SMB202, SMB210, SMB300, SMB302 or SMB311
+	 * @since 1.2
+	 */
 	public void setSmbMaxVer(DialectVersion smbMaxVer) {
 		this.smbMaxVer = smbMaxVer;
 	}

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbConfig.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbConfig.java
@@ -162,7 +162,7 @@ public class SmbConfig {
 	 * Sets the desired minimum SMB version value for what the Windows server will allow
 	 * during protocol transport negotiation.
 	 *
-	 * @param smbMinVer one of SMB1, SMB202, SMB210, SMB300, SMB302 or SMB311
+	 * @param _smbMinVer one of SMB1, SMB202, SMB210, SMB300, SMB302 or SMB311
 	 * @since 1.2
 	 */
 	public void setSmbMinVer(DialectVersion _smbMinVer) {
@@ -184,7 +184,7 @@ public class SmbConfig {
 	 * Sets the desired maximum SMB version value for what the Windows server will allow
 	 * during protocol transport negotiation.
 	 *
-	 * @param smbMaxVer one of SMB1, SMB202, SMB210, SMB300, SMB302 or SMB311
+	 * @param _smbMaxVer one of SMB1, SMB202, SMB210, SMB300, SMB302 or SMB311
 	 * @since 1.2
 	 */
 	public void setSmbMaxVer(DialectVersion _smbMaxVer) {

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbSessionFactory.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbSessionFactory.java
@@ -52,8 +52,8 @@ public class SmbSessionFactory extends SmbConfig implements SessionFactory<SmbFi
 
 	protected SmbSession createSession() throws IOException {
 		Properties props = new Properties();
-		props.setProperty("jcifs.smb.client.minVersion", this.getSmbMinVer().name());
-		props.setProperty("jcifs.smb.client.maxVersion", this.getSmbMaxVer().name());
+		props.setProperty("jcifs.smb.client.minVersion", this.getSmbMinVersion().name());
+		props.setProperty("jcifs.smb.client.maxVersion", this.getSmbMaxVersion().name());
 
 		SmbShare smbShare = new SmbShare(this, props);
 		smbShare.setReplaceFile(isReplaceFile());

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbSessionFactory.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbSessionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.integration.smb.session;
 
 import java.io.IOException;
+import java.util.Properties;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -29,7 +30,7 @@ import jcifs.smb.SmbFile;
  * The SMB session factory.
  *
  * @author Markus Spann
- * @since 1.0
+ * @author Gregory Bragg
  */
 public class SmbSessionFactory extends SmbConfig implements SessionFactory<SmbFile> {
 
@@ -39,6 +40,7 @@ public class SmbSessionFactory extends SmbConfig implements SessionFactory<SmbFi
 		logger.debug("New " + getClass().getName() + " created.");
 	}
 
+	@Override
 	public final SmbSession getSession() {
 		try {
 			return createSession();
@@ -49,7 +51,11 @@ public class SmbSessionFactory extends SmbConfig implements SessionFactory<SmbFi
 	}
 
 	protected SmbSession createSession() throws IOException {
-		SmbShare smbShare = new SmbShare(this);
+		Properties props = new Properties();
+		props.setProperty("jcifs.smb.client.minVersion", this.getSmbMinVer().name());
+		props.setProperty("jcifs.smb.client.maxVersion", this.getSmbMaxVer().name());
+
+		SmbShare smbShare = new SmbShare(this, props);
 		smbShare.setReplaceFile(isReplaceFile());
 		smbShare.setUseTempFile(isUseTempFile());
 

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbShare.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbShare.java
@@ -60,12 +60,15 @@ public class SmbShare extends SmbFile {
 
 	/**
 	 * Initializes the jCIFS library with default properties.
+	 *
 	 * @param _smbConfig the SMB share configuration
 	 * @throws IOException if an invalid SMB URL was constructed by jCIFS
+	 * @since 1.1
 	 */
 	public SmbShare(SmbConfig _smbConfig) throws IOException {
 		super(StringUtils.cleanPath(_smbConfig.validate().getUrl()),
-				SingletonContext.getInstance().withCredentials(new NtlmPasswordAuthenticator(
+				SingletonContext.getInstance().withCredentials(
+					new NtlmPasswordAuthenticator(
 						_smbConfig.getDomain(), _smbConfig.getUsername(), _smbConfig.getPassword())));
 	}
 
@@ -73,9 +76,11 @@ public class SmbShare extends SmbFile {
 	 * Initializes the jCIFS library with custom properties such as
 	 * 'jcifs.smb.client.minVersion' and 'jcifs.smb.client.maxVersion'
 	 * for setting the minimum/maximum SMB supported versions.
+	 *
 	 * @param _smbConfig the SMB share configuration
 	 * @param _props the custom property set for jCIFS to initialize
 	 * @throws IOException if an invalid property was set or an invalid SMB URL was constructed by jCIFS
+	 * @since 1.2
 	 */
 	public SmbShare(SmbConfig _smbConfig, Properties _props) throws IOException {
 		super(StringUtils.cleanPath(_smbConfig.validate().getUrl()),

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbShare.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbShare.java
@@ -60,7 +60,6 @@ public class SmbShare extends SmbFile {
 
 	/**
 	 * Initializes the jCIFS library with default properties.
-	 *
 	 * @param _smbConfig the SMB share configuration
 	 * @throws IOException if an invalid SMB URL was constructed by jCIFS
 	 * @since 1.1
@@ -76,7 +75,6 @@ public class SmbShare extends SmbFile {
 	 * Initializes the jCIFS library with custom properties such as
 	 * 'jcifs.smb.client.minVersion' and 'jcifs.smb.client.maxVersion'
 	 * for setting the minimum/maximum SMB supported versions.
-	 *
 	 * @param _smbConfig the SMB share configuration
 	 * @param _props the custom property set for jCIFS to initialize
 	 * @throws IOException if an invalid property was set or an invalid SMB URL was constructed by jCIFS

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbShare.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbShare.java
@@ -17,6 +17,7 @@
 package org.springframework.integration.smb.session;
 
 import java.io.IOException;
+import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.commons.logging.Log;
@@ -26,6 +27,8 @@ import org.springframework.core.NestedIOException;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
+import jcifs.config.PropertyConfiguration;
+import jcifs.context.BaseContext;
 import jcifs.context.SingletonContext;
 import jcifs.smb.NtlmPasswordAuthenticator;
 import jcifs.smb.SmbException;
@@ -55,10 +58,31 @@ public class SmbShare extends SmbFile {
 		super(StringUtils.cleanPath(url));
 	}
 
+	/**
+	 * Initializes the jCIFS library with default properties.
+	 * @param _smbConfig the SMB share configuration
+	 * @throws IOException if an invalid SMB URL was constructed by jCIFS
+	 */
 	public SmbShare(SmbConfig _smbConfig) throws IOException {
 		super(StringUtils.cleanPath(_smbConfig.validate().getUrl()),
 				SingletonContext.getInstance().withCredentials(new NtlmPasswordAuthenticator(
 						_smbConfig.getDomain(), _smbConfig.getUsername(), _smbConfig.getPassword())));
+	}
+
+	/**
+	 * Initializes the jCIFS library with custom properties such as
+	 * 'jcifs.smb.client.minVersion' and 'jcifs.smb.client.maxVersion'
+	 * for setting the minimum/maximum SMB supported versions.
+	 * @param _smbConfig the SMB share configuration
+	 * @param _props the custom property set for jCIFS to initialize
+	 * @throws IOException if an invalid property was set or an invalid SMB URL was constructed by jCIFS
+	 */
+	public SmbShare(SmbConfig _smbConfig, Properties _props) throws IOException {
+		super(StringUtils.cleanPath(_smbConfig.validate().getUrl()),
+				new BaseContext(
+						new PropertyConfiguration(_props)).withCredentials(
+								new NtlmPasswordAuthenticator(
+										_smbConfig.getDomain(), _smbConfig.getUsername(), _smbConfig.getPassword())));
 	}
 
 	public void init() throws NestedIOException {

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbShare.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbShare.java
@@ -80,9 +80,9 @@ public class SmbShare extends SmbFile {
 	public SmbShare(SmbConfig _smbConfig, Properties _props) throws IOException {
 		super(StringUtils.cleanPath(_smbConfig.validate().getUrl()),
 				new BaseContext(
-						new PropertyConfiguration(_props)).withCredentials(
-								new NtlmPasswordAuthenticator(
-										_smbConfig.getDomain(), _smbConfig.getUsername(), _smbConfig.getPassword())));
+					new PropertyConfiguration(_props)).withCredentials(
+						new NtlmPasswordAuthenticator(
+							_smbConfig.getDomain(), _smbConfig.getUsername(), _smbConfig.getPassword())));
 	}
 
 	public void init() throws NestedIOException {

--- a/spring-integration-smb/src/test/java/org/springframework/integration/smb/session/SmbSessionTests.java
+++ b/spring-integration-smb/src/test/java/org/springframework/integration/smb/session/SmbSessionTests.java
@@ -19,9 +19,11 @@ package org.springframework.integration.smb.session;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
+import java.util.Properties;
 
 import org.junit.Test;
 
+import jcifs.DialectVersion;
 import jcifs.smb.SmbFile;
 
 /**
@@ -134,4 +136,69 @@ public class SmbSessionTests {
 		smbSession.close();
 	}
 
+	@Test
+	public void testCreateSmbFileObjectWithSmb3Versions1() throws IOException {
+		Properties props = new Properties();
+		SmbConfig config = new SmbConfig();
+
+		config.setHost("myshare");
+		config.setPort(445);
+		config.setShareAndDir("shared/");
+		config.setSmbMinVer(DialectVersion.SMB300);
+		config.setSmbMaxVer(DialectVersion.SMB311);
+
+		props.setProperty("jcifs.smb.client.minVersion", config.getSmbMinVer().name());
+		props.setProperty("jcifs.smb.client.maxVersion", config.getSmbMaxVer().name());
+
+		SmbShare smbShare = new SmbShare(config, props);
+		SmbSession smbSession = new SmbSession(smbShare);
+
+		SmbFile smbFile = smbSession.createSmbFileObject("smb://myshare\\blubba");
+		assertEquals("smb://myshare/blubba", smbFile.getPath());
+		smbSession.close();
+	}
+
+	@Test
+	public void testCreateSmbFileObjectWithSmb3Versions2() throws IOException {
+		Properties props = new Properties();
+		SmbConfig config = new SmbConfig();
+
+		config.setHost("myshare");
+		config.setPort(445);
+		config.setShareAndDir("shared/");
+		config.setSmbMinVer(DialectVersion.SMB302);
+		config.setSmbMaxVer(DialectVersion.SMB311);
+
+		props.setProperty("jcifs.smb.client.minVersion", config.getSmbMinVer().name());
+		props.setProperty("jcifs.smb.client.maxVersion", config.getSmbMaxVer().name());
+
+		SmbShare smbShare = new SmbShare(config, props);
+		SmbSession smbSession = new SmbSession(smbShare);
+
+		SmbFile smbFile = smbSession.createSmbFileObject("smb://myshare\\blubba");
+		assertEquals("smb://myshare/blubba", smbFile.getPath());
+		smbSession.close();
+	}
+
+	@Test
+	public void testCreateSmbFileObjectWithSmb3Versions3() throws IOException {
+		Properties props = new Properties();
+		SmbConfig config = new SmbConfig();
+
+		config.setHost("myshare");
+		config.setPort(445);
+		config.setShareAndDir("shared/");
+		config.setSmbMinVer(DialectVersion.SMB311);
+		config.setSmbMaxVer(DialectVersion.SMB311);
+
+		props.setProperty("jcifs.smb.client.minVersion", config.getSmbMinVer().name());
+		props.setProperty("jcifs.smb.client.maxVersion", config.getSmbMaxVer().name());
+
+		SmbShare smbShare = new SmbShare(config, props);
+		SmbSession smbSession = new SmbSession(smbShare);
+
+		SmbFile smbFile = smbSession.createSmbFileObject("smb://myshare\\blubba");
+		assertEquals("smb://myshare/blubba", smbFile.getPath());
+		smbSession.close();
+	}
 }

--- a/spring-integration-smb/src/test/java/org/springframework/integration/smb/session/SmbSessionTests.java
+++ b/spring-integration-smb/src/test/java/org/springframework/integration/smb/session/SmbSessionTests.java
@@ -144,11 +144,11 @@ public class SmbSessionTests {
 		config.setHost("myshare");
 		config.setPort(445);
 		config.setShareAndDir("shared/");
-		config.setSmbMinVer(DialectVersion.SMB300);
-		config.setSmbMaxVer(DialectVersion.SMB311);
+		config.setSmbMinVersion(DialectVersion.SMB300);
+		config.setSmbMaxVersion(DialectVersion.SMB311);
 
-		props.setProperty("jcifs.smb.client.minVersion", config.getSmbMinVer().name());
-		props.setProperty("jcifs.smb.client.maxVersion", config.getSmbMaxVer().name());
+		props.setProperty("jcifs.smb.client.minVersion", config.getSmbMinVersion().name());
+		props.setProperty("jcifs.smb.client.maxVersion", config.getSmbMaxVersion().name());
 
 		SmbShare smbShare = new SmbShare(config, props);
 		SmbSession smbSession = new SmbSession(smbShare);
@@ -166,11 +166,11 @@ public class SmbSessionTests {
 		config.setHost("myshare");
 		config.setPort(445);
 		config.setShareAndDir("shared/");
-		config.setSmbMinVer(DialectVersion.SMB302);
-		config.setSmbMaxVer(DialectVersion.SMB311);
+		config.setSmbMinVersion(DialectVersion.SMB302);
+		config.setSmbMaxVersion(DialectVersion.SMB311);
 
-		props.setProperty("jcifs.smb.client.minVersion", config.getSmbMinVer().name());
-		props.setProperty("jcifs.smb.client.maxVersion", config.getSmbMaxVer().name());
+		props.setProperty("jcifs.smb.client.minVersion", config.getSmbMinVersion().name());
+		props.setProperty("jcifs.smb.client.maxVersion", config.getSmbMaxVersion().name());
 
 		SmbShare smbShare = new SmbShare(config, props);
 		SmbSession smbSession = new SmbSession(smbShare);
@@ -188,11 +188,11 @@ public class SmbSessionTests {
 		config.setHost("myshare");
 		config.setPort(445);
 		config.setShareAndDir("shared/");
-		config.setSmbMinVer(DialectVersion.SMB311);
-		config.setSmbMaxVer(DialectVersion.SMB311);
+		config.setSmbMinVersion(DialectVersion.SMB311);
+		config.setSmbMaxVersion(DialectVersion.SMB311);
 
-		props.setProperty("jcifs.smb.client.minVersion", config.getSmbMinVer().name());
-		props.setProperty("jcifs.smb.client.maxVersion", config.getSmbMaxVer().name());
+		props.setProperty("jcifs.smb.client.minVersion", config.getSmbMinVersion().name());
+		props.setProperty("jcifs.smb.client.maxVersion", config.getSmbMaxVersion().name());
 
 		SmbShare smbShare = new SmbShare(config, props);
 		SmbSession smbSession = new SmbSession(smbShare);


### PR DESCRIPTION
Fixes #208 

This will allow SmbSessionFactory to set the min/max versions of SMB as so:
        smbSession.setSmbMinVer(DialectVersion.SMB210);
        smbSession.setSmbMaxVer(DialectVersion.SMB311);

instead of the built in defaults of SMB1/SMB210. Doing so will allow the use of SMB3 dialects if the user so desires based on what the Windows server allows during protocol transport negotiation.
