### PR TITLE
Fix for memory leak issue #225

### DIFF
--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbSession.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbSession.java
@@ -406,7 +406,7 @@ public class SmbSession implements Session<SmbFile> {
 
 	@Override
 	public void close() {
-		this.smbShare.doClose();
+		this.smbShare.close();
 	}
 
 	/**


### PR DESCRIPTION
If SmbShare instantiates a BaseContext during construction then the
context will be closed on calling close().

Without this there's a ThreadLocal memory leak.