### PR TITLE
Fix memory leak on authentication error

### DIFF
--- a/spring-integration-smb/build.gradle
+++ b/spring-integration-smb/build.gradle
@@ -42,7 +42,7 @@ compileTestJava {
 ext {
 	idPrefix = 'smb'
 
-	jcifsVersion = '2.1.18'
+	jcifsVersion = '2.1.19'
 	log4jVersion = '2.12.1'
 	springIntegrationVersion = '5.2.1.RELEASE'
 

--- a/spring-integration-smb/build.gradle
+++ b/spring-integration-smb/build.gradle
@@ -42,7 +42,7 @@ compileTestJava {
 ext {
 	idPrefix = 'smb'
 
-	jcifsVersion = '2.1.11'
+	jcifsVersion = '2.1.18'
 	log4jVersion = '2.12.1'
 	springIntegrationVersion = '5.2.1.RELEASE'
 

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbSession.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbSession.java
@@ -55,6 +55,7 @@ import jcifs.smb.SmbFileOutputStream;
  * @author Artem Bilan
  * @author Prafull Kumar Soni
  * @author Gregory Bragg
+ * @author Adam Jones
  *
  */
 public class SmbSession implements Session<SmbFile> {

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbShare.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbShare.java
@@ -115,6 +115,14 @@ public class SmbShare extends SmbFile {
 			canRead = canRead();
 		}
 		catch (SmbException _ex) {
+			if (this.closeContext.get()) {
+				try {
+					getContext().close();
+				}
+				catch (CIFSException e) {
+					logger.error("Unable to close share: " + this);
+				}
+			}
 			throw new NestedIOException("Unable to initialize share: " + this, _ex);
 		}
 		Assert.isTrue(canRead, "Share is not accessible " + this);

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbShare.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbShare.java
@@ -39,6 +39,7 @@ import jcifs.smb.SmbFile;
 /**
  * @author Markus Spann
  * @author Gregory Bragg
+ * @author Adam Jones
  */
 public class SmbShare extends SmbFile {
 


### PR DESCRIPTION
I believe the root cause of this is in the jCIFS library but this mitigates the
problem.