### PR TITLE
Fix a memory leak in hazelcast LeaderInitiator

### DIFF
--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/leader/LeaderInitiatorTests.java
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/leader/LeaderInitiatorTests.java
@@ -227,23 +227,13 @@ public class LeaderInitiatorTests {
 		@Bean
 		public Config hazelcastConfig() {
 			Config config = new Config();
-			config.getCPSubsystemConfig().setCPMemberCount(3)
+			config.getCPSubsystemConfig().setCPMemberCount(0)
 					.setSessionHeartbeatIntervalSeconds(1);
 			return config;
 		}
 
 		@Bean(destroyMethod = "")
 		public HazelcastInstance hazelcastInstance() {
-			return Hazelcast.newHazelcastInstance(hazelcastConfig());
-		}
-
-		@Bean(destroyMethod = "")
-		public HazelcastInstance hazelcastInstance2() {
-			return Hazelcast.newHazelcastInstance(hazelcastConfig());
-		}
-
-		@Bean(destroyMethod = "")
-		public HazelcastInstance hazelcastInstance3() {
 			return Hazelcast.newHazelcastInstance(hazelcastConfig());
 		}
 


### PR DESCRIPTION
According to the hazelcast team: "The logic assumes that locks are generally acquired & released in a fairly short time or hold a very long time without unlocking. But in this case, is a bit different, it holds the lock for a long time but also does lock/unlock very frequently". The previous implementation used the described logic, first acquiring a lock and then doing frequent tryLock/unlock. Doing this leads to com.hazelcast.cp.internal.datastructures.lock.Lock#ownerInvocationRefUids to grow without ever being cleaned thus leading to an OutOfMemory error eventually.