### PR TITLE
Issue #246 deprecate file replace option, retain minor version

### DIFF
--- a/spring-integration-smb/README.md
+++ b/spring-integration-smb/README.md
@@ -18,7 +18,7 @@ Put the following block into pom.xml if using Maven:
     <dependency>
         <groupId>org.springframework.integration</groupId>
         <artifactId>spring-integration-smb</artifactId>
-        <version>1.2.0.RELEASE</version>
+        <version>1.3.0.RELEASE</version>
     </dependency>
 
 ## Changes
@@ -30,6 +30,11 @@ Put the following block into pom.xml if using Maven:
 ##### Version 1.2
  * Ability to set the SMB min/max versions in the `SmbSessionFactory` via configuration in the JCIFS library
  * Ability to use a custom implementation of the `jcifs.CIFSContext` interface in the `SmbSessionFactory`
+ 
+##### Version 1.3
+ * Updated to use the latest version of the [JCIFS](https://github.com/codelibs/jcifs) library
+ * Added implementation for `SmbMessageHandler`
+ * Deprecated legacy `replaceFile` and `useTempFile` flags in `SmbConfig`
 
 ## Overview
 
@@ -48,15 +53,14 @@ For XML configuration the `<int-smb:inbound-channel-adapter>` component is provi
 
 ### SMB Outbound Channel Adapter
 
-There is no (yet) some SMB specific requirements for files transferring to SMB, so for XML `<int-smb:outbound-channel-adapter>` component we simply reuse an existing `FileTransferringMessageHandler`.
-In case of Java configuration that `FileTransferringMessageHandler` should be supplied with the `SmbSessionFactory` (or `SmbRemoteFileTemplate`).
+For writing files to a SMB share, and for XML `<int-smb:outbound-channel-adapter>` component we use the `SmbMessageHandler`.
+In case of Java configuration a `SmbMessageHandler` should be supplied with the `SmbSessionFactory` (or `SmbRemoteFileTemplate`).
 
 ````java
-@ServiceActivator(inputChannel = "storeToSmb")
 @Bean
+@ServiceActivator(inputChannel = "storeToSmbShare")
 public MessageHandler smbMessageHandler(SmbSessionFactory smbSessionFactory) {
-    FileTransferringMessageHandler<SmbFile> handler =
-                new FileTransferringMessageHandler<>(smbSessionFactory);
+    SmbMessageHandler handler = new SmbMessageHandler(smbSessionFactory);
     handler.setRemoteDirectoryExpression(
                 new LiteralExpression("remote-target-dir"));
     handler.setFileNameGenerator(m ->

--- a/spring-integration-smb/README.md
+++ b/spring-integration-smb/README.md
@@ -13,12 +13,12 @@ This module adds Spring Integration support for [Server Message Block][] (SMB).
 
 ## Using Maven
 
-Put the following block into pom.xml if using Maven:
+Put the following block into pom.xml if using Maven, set the `<version>` tag to the desired release:
 
     <dependency>
         <groupId>org.springframework.integration</groupId>
         <artifactId>spring-integration-smb</artifactId>
-        <version>1.3.0.RELEASE</version>
+        <version></version>
     </dependency>
 
 ## Changes
@@ -31,7 +31,7 @@ Put the following block into pom.xml if using Maven:
  * Ability to set the SMB min/max versions in the `SmbSessionFactory` via configuration in the JCIFS library
  * Ability to use a custom implementation of the `jcifs.CIFSContext` interface in the `SmbSessionFactory`
  
-##### Version 1.3
+##### Version 1.2.2
  * Updated to use the latest version of the [JCIFS](https://github.com/codelibs/jcifs) library
  * Added implementation for `SmbMessageHandler`
  * Deprecated legacy `replaceFile` and `useTempFile` flags in `SmbConfig`

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/outbound/SmbMessageHandler.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/outbound/SmbMessageHandler.java
@@ -48,7 +48,6 @@ public class SmbMessageHandler extends FileTransferringMessageHandler<SmbFile> {
 
 	public SmbMessageHandler(SmbRemoteFileTemplate remoteFileTemplate, FileExistsMode mode) {
 		super(remoteFileTemplate, mode);
-		throw new UnsupportedOperationException("do not use, unsupported constructor");
 	}
 
 }

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/outbound/SmbMessageHandler.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/outbound/SmbMessageHandler.java
@@ -18,8 +18,10 @@ package org.springframework.integration.smb.outbound;
 
 import org.springframework.integration.file.remote.handler.FileTransferringMessageHandler;
 import org.springframework.integration.file.remote.session.SessionFactory;
+import org.springframework.integration.file.support.FileExistsMode;
 import org.springframework.integration.smb.session.SmbRemoteFileTemplate;
 import org.springframework.integration.smb.session.SmbSessionFactory;
+import org.springframework.util.Assert;
 
 import jcifs.smb.SmbFile;
 
@@ -38,6 +40,17 @@ public class SmbMessageHandler extends FileTransferringMessageHandler<SmbFile> {
 	@SuppressWarnings("deprecation")
 	public SmbMessageHandler(SessionFactory<SmbFile> sessionFactory) {
 		super(sessionFactory);
+
+		if (sessionFactory instanceof SmbSessionFactory) {
+			SmbSessionFactory smbSessionFactory = (SmbSessionFactory) sessionFactory;
+			smbSessionFactory.setReplaceFile(true);
+		}
+	}
+
+	@SuppressWarnings("deprecation")
+	public SmbMessageHandler(SessionFactory<SmbFile> sessionFactory, FileExistsMode mode) {
+		super(new SmbRemoteFileTemplate(sessionFactory));
+		Assert.isTrue(mode == FileExistsMode.REPLACE, "Only FileExistsMode.REPLACE is supported.");
 
 		if (sessionFactory instanceof SmbSessionFactory) {
 			SmbSessionFactory smbSessionFactory = (SmbSessionFactory) sessionFactory;

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/outbound/SmbMessageHandler.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/outbound/SmbMessageHandler.java
@@ -18,7 +18,6 @@ package org.springframework.integration.smb.outbound;
 
 import org.springframework.integration.file.remote.handler.FileTransferringMessageHandler;
 import org.springframework.integration.file.remote.session.SessionFactory;
-import org.springframework.integration.file.support.FileExistsMode;
 import org.springframework.integration.smb.session.SmbRemoteFileTemplate;
 import org.springframework.integration.smb.session.SmbSessionFactory;
 
@@ -30,24 +29,20 @@ import jcifs.smb.SmbFile;
 *
 * @author Gregory Bragg
 *
-* @since 1.3
+* @since 1.2.2
 *
 * @see SmbRemoteFileTemplate
 */
 public class SmbMessageHandler extends FileTransferringMessageHandler<SmbFile> {
 
+	@SuppressWarnings("deprecation")
 	public SmbMessageHandler(SessionFactory<SmbFile> sessionFactory) {
-		this(new SmbRemoteFileTemplate(sessionFactory));
-		SmbSessionFactory smbSessionFactory = (SmbSessionFactory) sessionFactory;
-		smbSessionFactory.setReplaceFile(true);
-	}
+		super(sessionFactory);
 
-	public SmbMessageHandler(SmbRemoteFileTemplate remoteFileTemplate) {
-		super(remoteFileTemplate);
-	}
-
-	public SmbMessageHandler(SmbRemoteFileTemplate remoteFileTemplate, FileExistsMode mode) {
-		super(remoteFileTemplate, mode);
+		if (sessionFactory instanceof SmbSessionFactory) {
+			SmbSessionFactory smbSessionFactory = (SmbSessionFactory) sessionFactory;
+			smbSessionFactory.setReplaceFile(true);
+		}
 	}
 
 }

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/outbound/SmbMessageHandler.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/outbound/SmbMessageHandler.java
@@ -21,7 +21,6 @@ import org.springframework.integration.file.remote.session.SessionFactory;
 import org.springframework.integration.file.support.FileExistsMode;
 import org.springframework.integration.smb.session.SmbRemoteFileTemplate;
 import org.springframework.integration.smb.session.SmbSessionFactory;
-import org.springframework.util.Assert;
 
 import jcifs.smb.SmbFile;
 
@@ -49,12 +48,13 @@ public class SmbMessageHandler extends FileTransferringMessageHandler<SmbFile> {
 
 	@SuppressWarnings("deprecation")
 	public SmbMessageHandler(SessionFactory<SmbFile> sessionFactory, FileExistsMode mode) {
-		super(new SmbRemoteFileTemplate(sessionFactory));
-		Assert.isTrue(mode == FileExistsMode.REPLACE, "Only FileExistsMode.REPLACE is supported.");
+		super(new SmbRemoteFileTemplate(sessionFactory), mode);
 
-		if (sessionFactory instanceof SmbSessionFactory) {
-			SmbSessionFactory smbSessionFactory = (SmbSessionFactory) sessionFactory;
-			smbSessionFactory.setReplaceFile(true);
+		if (mode == FileExistsMode.REPLACE) {
+			if (sessionFactory instanceof SmbSessionFactory) {
+				SmbSessionFactory smbSessionFactory = (SmbSessionFactory) sessionFactory;
+				smbSessionFactory.setReplaceFile(true);
+			}
 		}
 	}
 

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/outbound/SmbMessageHandler.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/outbound/SmbMessageHandler.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.smb.outbound;
+
+import org.springframework.integration.file.remote.handler.FileTransferringMessageHandler;
+import org.springframework.integration.file.remote.session.SessionFactory;
+import org.springframework.integration.file.support.FileExistsMode;
+import org.springframework.integration.smb.session.SmbRemoteFileTemplate;
+import org.springframework.integration.smb.session.SmbSessionFactory;
+
+import jcifs.smb.SmbFile;
+
+/**
+* The SMB specific {@link FileTransferringMessageHandler} extension. Based on the
+* {@link SmbRemoteFileTemplate}.
+*
+* @author Gregory Bragg
+*
+* @since 1.3
+*
+* @see SmbRemoteFileTemplate
+*/
+public class SmbMessageHandler extends FileTransferringMessageHandler<SmbFile> {
+
+	public SmbMessageHandler(SessionFactory<SmbFile> sessionFactory) {
+		this(new SmbRemoteFileTemplate(sessionFactory));
+		SmbSessionFactory smbSessionFactory = (SmbSessionFactory) sessionFactory;
+		smbSessionFactory.setReplaceFile(true);
+	}
+
+	public SmbMessageHandler(SmbRemoteFileTemplate remoteFileTemplate) {
+		super(remoteFileTemplate);
+	}
+
+	public SmbMessageHandler(SmbRemoteFileTemplate remoteFileTemplate, FileExistsMode mode) {
+		super(remoteFileTemplate, mode);
+		throw new UnsupportedOperationException("do not use, unsupported constructor");
+	}
+
+}

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/outbound/SmbMessageHandler.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/outbound/SmbMessageHandler.java
@@ -50,11 +50,9 @@ public class SmbMessageHandler extends FileTransferringMessageHandler<SmbFile> {
 	public SmbMessageHandler(SessionFactory<SmbFile> sessionFactory, FileExistsMode mode) {
 		super(new SmbRemoteFileTemplate(sessionFactory), mode);
 
-		if (mode == FileExistsMode.REPLACE) {
-			if (sessionFactory instanceof SmbSessionFactory) {
-				SmbSessionFactory smbSessionFactory = (SmbSessionFactory) sessionFactory;
-				smbSessionFactory.setReplaceFile(true);
-			}
+		if (sessionFactory instanceof SmbSessionFactory) {
+			SmbSessionFactory smbSessionFactory = (SmbSessionFactory) sessionFactory;
+			smbSessionFactory.setReplaceFile(true);
 		}
 	}
 

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbConfig.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,8 +49,18 @@ public class SmbConfig {
 
 	private String shareAndDir;
 
+	/**
+	 * do not use.
+	 * @deprecated as of 1.3
+	 */
+	@Deprecated
 	private boolean replaceFile = false;
 
+	/**
+	 * do not use.
+	 * @deprecated as of 1.3
+	 */
+	@Deprecated
 	private boolean useTempFile = false;
 
 	/**
@@ -131,18 +141,42 @@ public class SmbConfig {
 		return this.shareAndDir;
 	}
 
+	/**
+	 * do not use.
+	 * @param _replaceFile true/false
+	 * @deprecated as of 1.3
+	 */
+	@Deprecated
 	public void setReplaceFile(boolean _replaceFile) {
 		this.replaceFile = _replaceFile;
 	}
 
+	/**
+	 * do not use.
+	 * @return true/false
+	 * @deprecated as of 1.3
+	 */
+	@Deprecated
 	public boolean isReplaceFile() {
 		return this.replaceFile;
 	}
 
+	/**
+	 * do not use.
+	 * @param _useTempFile true/false
+	 * @deprecated as of 1.3
+	 */
+	@Deprecated
 	void setUseTempFile(boolean _useTempFile) {
 		this.useTempFile = _useTempFile;
 	}
 
+	/**
+	 * do not use.
+	 * @return true/false
+	 * @deprecated as of 1.3
+	 */
+	@Deprecated
 	public boolean isUseTempFile() {
 		return this.useTempFile;
 	}

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbConfig.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbConfig.java
@@ -51,14 +51,14 @@ public class SmbConfig {
 
 	/**
 	 * do not use.
-	 * @deprecated as of 1.3
+	 * @deprecated as of 1.2.2
 	 */
 	@Deprecated
 	private boolean replaceFile = false;
 
 	/**
 	 * do not use.
-	 * @deprecated as of 1.3
+	 * @deprecated as of 1.2.2
 	 */
 	@Deprecated
 	private boolean useTempFile = false;
@@ -144,7 +144,7 @@ public class SmbConfig {
 	/**
 	 * do not use.
 	 * @param _replaceFile true/false
-	 * @deprecated as of 1.3
+	 * @deprecated as of 1.2.2
 	 */
 	@Deprecated
 	public void setReplaceFile(boolean _replaceFile) {
@@ -154,7 +154,7 @@ public class SmbConfig {
 	/**
 	 * do not use.
 	 * @return true/false
-	 * @deprecated as of 1.3
+	 * @deprecated as of 1.2.2
 	 */
 	@Deprecated
 	public boolean isReplaceFile() {
@@ -164,7 +164,7 @@ public class SmbConfig {
 	/**
 	 * do not use.
 	 * @param _useTempFile true/false
-	 * @deprecated as of 1.3
+	 * @deprecated as of 1.2.2
 	 */
 	@Deprecated
 	void setUseTempFile(boolean _useTempFile) {
@@ -174,7 +174,7 @@ public class SmbConfig {
 	/**
 	 * do not use.
 	 * @return true/false
-	 * @deprecated as of 1.3
+	 * @deprecated as of 1.2.2
 	 */
 	@Deprecated
 	public boolean isUseTempFile() {

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbRemoteFileTemplate.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbRemoteFileTemplate.java
@@ -22,7 +22,7 @@ import org.springframework.integration.file.remote.session.SessionFactory;
 import jcifs.smb.SmbFile;
 
 /**
- * The SMP-specific {@link RemoteFileTemplate} implementation.
+ * The SMB-specific {@link RemoteFileTemplate} implementation.
  *
  * @author Artem Bilan
  */

--- a/spring-integration-smb/src/test/java/org/springframework/integration/smb/outbound/SmbSendingMessageHandlerTests.java
+++ b/spring-integration-smb/src/test/java/org/springframework/integration/smb/outbound/SmbSendingMessageHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2018 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,6 @@ import org.mockito.stubbing.Answer;
 
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.expression.common.LiteralExpression;
-import org.springframework.integration.file.remote.handler.FileTransferringMessageHandler;
 import org.springframework.integration.smb.AbstractBaseTests;
 import org.springframework.integration.smb.session.SmbSession;
 import org.springframework.integration.smb.session.SmbSessionFactory;
@@ -45,6 +44,7 @@ import jcifs.smb.SmbFile;
  * @author Markus Spann
  * @author Artem Bilan
  * @author Prafull Kumar Soni
+ * @author Gregory Bragg
  */
 public class SmbSendingMessageHandlerTests extends AbstractBaseTests {
 
@@ -62,13 +62,13 @@ public class SmbSendingMessageHandlerTests extends AbstractBaseTests {
 		smbSessionFactory.setUsername("sambaguest");
 		smbSessionFactory.setPassword("sambaguest");
 		smbSessionFactory.setShareAndDir("smb-share/");
-		smbSessionFactory.setReplaceFile(true);
+		//smbSessionFactory.setReplaceFile(true);  // deprecated as of 1.3
 	}
 
 	@Test
 	public void testHandleFileContentMessage() {
 		File file = createNewFile("remote-target-dir/handlerContent.test");
-		FileTransferringMessageHandler<?> handler = new FileTransferringMessageHandler<SmbFile>(smbSessionFactory);
+		SmbMessageHandler handler = new SmbMessageHandler(smbSessionFactory);
 		handler.setRemoteDirectoryExpression(new LiteralExpression("remote-target-dir"));
 		handler.setFileNameGenerator(message -> "handlerContent.test");
 		handler.setAutoCreateDirectory(true);
@@ -81,7 +81,7 @@ public class SmbSendingMessageHandlerTests extends AbstractBaseTests {
 	@Test
 	public void testHandleFileAsByte() {
 		File file = createNewFile("remote-target-dir/handlerContent.test");
-		FileTransferringMessageHandler<?> handler = new FileTransferringMessageHandler<SmbFile>(smbSessionFactory);
+		SmbMessageHandler handler = new SmbMessageHandler(smbSessionFactory);
 		handler.setRemoteDirectoryExpression(new LiteralExpression("remote-target-dir"));
 		handler.setFileNameGenerator(message -> "handlerContent.test");
 		handler.setBeanFactory(mock(BeanFactory.class));
@@ -93,7 +93,7 @@ public class SmbSendingMessageHandlerTests extends AbstractBaseTests {
 //	@Test
 //	public void testHandleFileMessage() throws Exception {
 //		File file = createNewFile("remote-target-dir/template.mf.test");
-//		FileTransferringMessageHandler<?> handler = new FileTransferringMessageHandler<SmbFile>(smbSessionFactory);
+//		SmbMessageHandler handler = new SmbMessageHandler(smbSessionFactory);
 //		handler.setRemoteDirectoryExpression(new LiteralExpression("remote-target-dir"));
 //		handler.setFileNameGenerator(new FileNameGenerator() {
 //			public String generateFileName(Message<?> message) {
@@ -115,6 +115,7 @@ public class SmbSendingMessageHandlerTests extends AbstractBaseTests {
 
 				doAnswer(new Answer<Object>() {
 
+					@Override
 					public Object answer(InvocationOnMock _invocation) throws Throwable {
 						String path = (String) _invocation.getArguments()[0];
 						OutputStream os = (OutputStream) _invocation.getArguments()[1];
@@ -136,6 +137,7 @@ public class SmbSendingMessageHandlerTests extends AbstractBaseTests {
 
 				doAnswer(new Answer<Object>() {
 
+					@Override
 					public Object answer(InvocationOnMock _invocation) {
 						String path = (String) _invocation.getArguments()[0];
 						new File(path).mkdirs();

--- a/spring-integration-smb/src/test/java/org/springframework/integration/smb/outbound/SmbSendingMessageHandlerTests.java
+++ b/spring-integration-smb/src/test/java/org/springframework/integration/smb/outbound/SmbSendingMessageHandlerTests.java
@@ -62,7 +62,7 @@ public class SmbSendingMessageHandlerTests extends AbstractBaseTests {
 		smbSessionFactory.setUsername("sambaguest");
 		smbSessionFactory.setPassword("sambaguest");
 		smbSessionFactory.setShareAndDir("smb-share/");
-		//smbSessionFactory.setReplaceFile(true);  // deprecated as of 1.3
+		//smbSessionFactory.setReplaceFile(true);  // deprecated as of 1.2.2
 	}
 
 	@Test

--- a/spring-integration-smb/src/test/java/org/springframework/integration/smb/outbound/SmbSendingMessageHandlerTests.java
+++ b/spring-integration-smb/src/test/java/org/springframework/integration/smb/outbound/SmbSendingMessageHandlerTests.java
@@ -62,7 +62,6 @@ public class SmbSendingMessageHandlerTests extends AbstractBaseTests {
 		smbSessionFactory.setUsername("sambaguest");
 		smbSessionFactory.setPassword("sambaguest");
 		smbSessionFactory.setShareAndDir("smb-share/");
-		//smbSessionFactory.setReplaceFile(true);  // deprecated as of 1.2.2
 	}
 
 	@Test


### PR DESCRIPTION
@artembilan as discussed in PR #257:

"For the current one I suggest the plan like this:
1.	Bring back your SmbMessageHandler, but set replaceFile on the provided SmbSessionFactory, not SmbRemoteFileTemplate.
2.	Deprecate those options on the SmbSessionFactory to discourage end-users to use them explicitly.
3.	Leave the logic as is in the SmbSession as is.

This way we should nail both birds: have options deprecated and retain the old behavior in both write() and rename()."

